### PR TITLE
Remove transitionEnd event listener after animation end

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -121,11 +121,12 @@ class FlipMove extends Component {
     });
 
     if ( this.props.onStart ) this.props.onStart(child, domNode);
-
-    domNode.addEventListener(transitionEnd, () => {
+    let onFinishHandler = () =>{
       domNode.style.transition = '';
       if ( this.props.onFinish ) this.props.onFinish(child, domNode);
-    });
+      domNode.removeEventListener(transitionEnd, onFinishHandler)
+    };
+    domNode.addEventListener(transitionEnd, onFinishHandler);
   }
 
   childrenWithRefs () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -41,8 +41,15 @@ describe('FlipMove', () => {
           staggerDurationBy: 0,
           articles
         };
+        this.count = 0;
       }
 
+      onFinishHandler(){
+        this.count++;
+      }
+      onStartHandler(){
+        this.count--;
+      }
       renderArticles() {
         return this.state.articles.map( article => (
           <ListItem key={article.id} id={article.id} name={article.name} />
@@ -56,6 +63,8 @@ describe('FlipMove', () => {
               duration={this.state.duration}
               staggerDelayBy={this.state.staggerDelayBy}
               staggerDurationBy={this.state.staggerDurationBy}
+              onFinish={::this.onFinishHandler}
+              onStart={::this.onStartHandler}
             >
               { this.renderArticles() }
             </FlipMove>
@@ -177,6 +186,23 @@ describe('FlipMove', () => {
       });
     });
 
+    describe('callbacks', () => {
+      before(()=>{
+        renderedComponent.setState({
+          articles:articles.reverse()});
+      });
+
+      it('onStart callback should set count to 0',()=>{
+        expect(renderedComponent.count).to.equal(-2);
+      });
+
+      it('onFinish callback should set count to 2', (done)=>{
+        setTimeout(() => {
+          expect(renderedComponent.count).to.equal(0);
+          done();
+        }, 750)
+      })
+    });
 
     describe('duration propType', () => {
       let originalPositions;


### PR DESCRIPTION
TransitionEnd event listeners not removed automatically, after domNodes reordering, u can check it with this code:
```javascript
import React, {Component} from 'react';
import ReactDom from 'react-dom';
import FlipMove from 'react-flip-move';
import _ from 'lodash'

class Main extends Component{
    constructor(props){
        super(props);
        this.state = {
            arr:_.range(3)
        };
        this.count = 0;
    }
    shuffle(){
        this.setState({arr:this.state.arr.reverse()})
    }
    start(){
        console.log('start');
    }
    finish(){
        this.count++;
        console.log(this.count);
    }
    render(){
        let {arr} = this.state;
        let style = {fontSize:'34px', background:'silver', border:'1px solid black'};
        return (<div className="container">
            <FlipMove
                duration={500}
                onFinish={::this.finish}
                onStart={::this.start}
            >
              {arr.map((i,key)=> {
                  return (<div key={i} style={style} onClick={::this.shuffle}>{i}</div>)
              })}
            </FlipMove>
        </div>);
    }
}
ReactDom.render(<Main/>,document.querySelector('#app'));
```
After some clicking ur console output will be something like 

```javascript
2 start
 1
 2
2 start
 3
 4
 5
 6
2 start
 7
 8
 9
 10
 11
 12
2 start
etc
```
So we can remove it manually with removeEventListener.