### PR TITLE
Add new prop `getPosition()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Flip Move uses the [_FLIP technique_](https://aerotwist.com/blog/flip-your-anima
   * [className](https://github.com/joshwcomeau/react-flip-move#classname)
   * [typeName](https://github.com/joshwcomeau/react-flip-move#typename)
   * [disableAllAnimations](https://github.com/joshwcomeau/react-flip-move#disableallanimations)
+  * [getPosition](https://github.com/joshwcomeau/react-flip-move#getPosition)
   * [HTML Attributes](https://github.com/joshwcomeau/react-flip-move#html-attributes)
 * [Gotchas](https://github.com/joshwcomeau/react-flip-move#gotchas)
 * [Changelog](https://github.com/joshwcomeau/react-flip-move#changelog)

--- a/README.md
+++ b/README.md
@@ -468,6 +468,19 @@ Sometimes, you may wish to temporarily disable the animations and have the norma
 
 ---
 
+### `getPosition`
+
+| **Accepted Types:** | **Default Value**       |
+|---------------------|-------------------------|
+|  `Function`         | `getBoundingClientRect` |
+
+
+This function is called with a DOM node as the only argument. It should return an object as specified by the [getBoundingClientRect() spec](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+
+For normal usage of FlipMove you won't need this. An example of usage is when FlipMove is used in a container that is scaled using CSS. You can correct the values from `getBoundingClientRect` by using this prop.
+
+---
+
 ### HTML Attributes
 
 FlipMove creates its own DOM node to wrap the children it needs to animate. Sometimes, you'll want to be able to pass specific HTML attributes to this node.

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -89,7 +89,7 @@ class FlipMove extends Component {
 
     // Calculate the parentBox. This is used to find childBoxes relative
     // to the parent container, not the viewport.
-    const parentBox = this.parentElement.getBoundingClientRect();
+    const parentBox = this.props.getPosition(this.parentElement);
 
     // Get the bounding boxes of all currently-rendered, keyed children.
     const newBoundingBoxes = this.props.children.reduce( (boxes, child) => {
@@ -99,7 +99,7 @@ class FlipMove extends Component {
 
       const domNode     = ReactDOM.findDOMNode( this.refs[child.key] );
 
-      const childBox    = domNode.getBoundingClientRect();
+      const childBox    = this.props.getPosition(domNode);
       const relativeBox = {
         'top':    childBox['top']  - parentBox['top'],
         'left':   childBox['left'] - parentBox['left'],
@@ -192,7 +192,7 @@ class FlipMove extends Component {
       return this.setState({ children: this.props.children });
     }
 
-    this.parentBox = this.parentElement.getBoundingClientRect();
+    this.parentBox = this.props.getPosition(this.parentElement);
 
     // we need to make all leaving nodes "invisible" to the layout calculations
     // that will take place in the next step (this.runAnimation).
@@ -416,7 +416,7 @@ class FlipMove extends Component {
     // TEMP: A mystery bug is sometimes causing unnecessary boundingBoxes to
     // remain. Until this bug can be solved, this band-aid fix does the job:
     const defaultBox = { left: 0, top: 0 };
-    const newBox  = domNode.getBoundingClientRect();
+    const newBox  = this.props.getPosition(domNode);
     const oldBox  = this.boundingBoxes[key] || defaultBox;
     const relativeBox = {
       top:  newBox.top - this.parentBox.top,

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -161,7 +161,8 @@ function propConverter(ComposedComponent) {
                               PropTypes.string,
                               PropTypes.bool,
                               PropTypes.object
-                            ])
+                            ]),
+      getPosition:          PropTypes.func,
       };
 
 
@@ -174,6 +175,7 @@ function propConverter(ComposedComponent) {
       typeName:           'div',
       enterAnimation:     defaultPreset,
       leaveAnimation:     defaultPreset,
+      getPosition:        node => node.getBoundingClientRect(),
     };
   }
 }

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,6 +3,7 @@ import { storiesOf, action } from '@kadira/storybook';
 import shuffle from 'lodash/shuffle';
 import sampleSize from 'lodash/sampleSize';
 import range from 'lodash/range';
+import _ from 'lodash';
 
 import FlipMove from '../src/FlipMove.js';
 
@@ -108,6 +109,21 @@ storiesOf('FlipMove', module)
   .add('delegated prop - width', () => (
     <Controls typeName="table" width="50%" />
   ))
+  .add('inside a scaled container', () => (
+    <Controls style={{transform: 'scale(0.5)'}} getPosition={getPosition} />
+  ))
+
+function getPosition(node) {
+  const rect = node.getBoundingClientRect();
+  const newRect = {};
+
+  for (const prop in rect) {
+    newRect[prop] = rect[prop] / 0.5;
+  }
+
+  return newRect;
+}
+
 
 // Controlling component
 const items = [


### PR DESCRIPTION
Hi @joshwcomeau!
This is based on our conversation in https://github.com/joshwcomeau/react-flip-move/issues/55.

This is my proposal on how we could fix the scaling issue with a more generic solution than a `scaleFactor` prop. I couldn't quite decide on what to call the prop. I though about using `getRect` or even `getRekt` but I didn't know if you saw the humor in that. ([get rekt](http://www.urbandictionary.com/define.php?term=get%20rekt))

I tried to make the new code fit in with your existing code as much as possible but feel free to change whatever you want or send me notes on what I should change.

Let me know what you think! I would love to be able to use this prop in our application ASAP :)

