### PR TITLE
Feature/maintain container height container size

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Flip Move uses the [_FLIP technique_](https://aerotwist.com/blog/flip-your-anima
   * [staggerDelayBy](https://github.com/joshwcomeau/react-flip-move#staggerdelayby)
   * [enterAnimation](https://github.com/joshwcomeau/react-flip-move#enteranimation)
   * [leaveAnimation](https://github.com/joshwcomeau/react-flip-move#leaveanimation)
+  * [maintainContainerHeight](https://github.com/joshwcomeau/react-flip-move#maintaincontainerheight)
   * [onStart](https://github.com/joshwcomeau/react-flip-move#onstart)
   * [onFinish](https://github.com/joshwcomeau/react-flip-move#onfinish)
   * [onStartAll](https://github.com/joshwcomeau/react-flip-move#onstartall)
@@ -366,6 +367,18 @@ const customLeaveAnimation = {
 ```
 
 It is recommended that you stick to hardware-accelerated CSS properties for optimal performance: transform and opacity.
+
+---
+
+### `maintainContainerHeight`
+
+| **Accepted Types:** | **Default Value** |
+|---------------------|-------------------|
+|  `Boolean`          | `false`           |
+
+Do not collapse container height until after leaving animations complete.
+
+When `false`, children are immediately removed from the DOM flow as they animate away. Setting this value to `true` will maintain the height of the container until after their leaving animation completes.
 
 ---
 

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -236,17 +236,24 @@ class FlipMove extends Component {
         // We need to find the height of the container *without* the padding
         // element. Since it's possible that the padding element might already
         // be present, we first set its height to 0. This allows the container to
-        // collapse down to the size of just its content.
+        // collapse down to the size of just its content (plus container padding
+        // or borders if any).
         this.heightPlaceholder.style.height = 0;
-        const contentHeight = this.props.getPosition(this.parentElement).height;
+        const collapsedHeight = this.props.getPosition(this.parentElement).height;
 
         // Find the distance by which the container would be collapsed by elements
         // leaving. We compare the temporarily available `collapsedHeight` with
         // the previously cached container height.
-        const collapseHeight = this.parentBox.height - contentHeight;
+        const reductionInHeight = this.parentBox.height - collapsedHeight;
 
-        // Update the padding element's height.
-        this.heightPlaceholder.style.height = Math.max(0, collapseHeight) + 'px';
+        // If the container has become shorter, update the padding element's
+        // height to take up the difference. Otherwise set its height to zero for
+        // no effect.
+        if ( reductionInHeight > 0 ) {
+          this.heightPlaceholder.style.height = `${reductionInHeight}px`;
+        } else {
+          this.heightPlaceholder.style.height = 0;
+        }
       }
     }
 

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -233,9 +233,20 @@ class FlipMove extends Component {
         domNode.style.right = leavingBoundingBox.right - cleanedComputed['margin-right'] + 'px';
       });
 
-      const newHeight = this.props.getPosition(this.parentElement).height;
-      const collapseHeight = this.parentBox.height - newHeight;
-      this.leavingPaddingElement.style.height = collapseHeight + 'px';
+      // We need to find the height of the container *without* the padding
+      // element. Since it's possible that the padding element might already
+      // be present, we first set its height to 0. This allows the container to
+      // collapse down to the size of just its content.
+      this.leavingPaddingElement.style.height = 0;
+      const contentHeight = this.props.getPosition(this.parentElement).height;
+
+      // Find the distance by which the container would be collapsed by elements
+      // leaving. We compare the temporarily available `collapsedHeight` with
+      // the previously cached container height.
+      const collapseHeight = this.parentBox.height - contentHeight;
+
+      // Update the padding element's height.
+      this.leavingPaddingElement.style.height = Math.max(0, collapseHeight) + 'px';
     }
 
     const dynamicChildren = this.state.children.filter(

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -104,7 +104,8 @@ class FlipMove extends Component {
         'top':    childBox['top']  - parentBox['top'],
         'left':   childBox['left'] - parentBox['left'],
         'right':  parentBox['right'] - childBox['right'],
-        'bottom': parentBox['bottom'] - childBox['bottom']
+        'bottom': parentBox['bottom'] - childBox['bottom'],
+        'height': childBox['height']
       };
 
       return { ...boxes, [child.key]: relativeBox };
@@ -476,9 +477,36 @@ class FlipMove extends Component {
 
 
   childrenWithRefs() {
-    return this.state.children.map( child => {
+    const { children } = this.state;
+
+    const childNodes = children.map( child => {
       return React.cloneElement(child, { ref: child.key });
     });
+
+    // Sum the height of all boxes leaving the document flow.
+    const leavingHeight = children.reduce( (height, child) => {
+      return child.leaving
+        ? height + this.boundingBoxes[child.key].height
+        : height;
+    }, 0)
+
+    // If elements are indeed disappearing then create an invisible child
+    // element at the end of the list whose height will prevent the
+    // container from collapsing prematurely.
+    if (leavingHeight > 0) {
+      childNodes.push(
+        <div
+          key='leaving-padding'
+          style={{
+            // This should be `visibility: hidden` - blue is just for review.
+            background: 'blue',
+            height: leavingHeight
+          }}
+        />
+      );
+    }
+
+    return childNodes;
   }
 
 

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -68,7 +68,6 @@ class FlipMove extends Component {
     this.parentElement = ReactDOM.findDOMNode(this);
   }
 
-
   componentDidUpdate(previousProps) {
     // If the children have been re-arranged, moved, or added/removed,
     // trigger the main FLIP animation.
@@ -104,8 +103,7 @@ class FlipMove extends Component {
         'top':    childBox['top']  - parentBox['top'],
         'left':   childBox['left'] - parentBox['left'],
         'right':  parentBox['right'] - childBox['right'],
-        'bottom': parentBox['bottom'] - childBox['bottom'],
-        'height': childBox['height']
+        'bottom': parentBox['bottom'] - childBox['bottom']
       };
 
       return { ...boxes, [child.key]: relativeBox };
@@ -234,6 +232,10 @@ class FlipMove extends Component {
         domNode.style.left  = leavingBoundingBox.left - cleanedComputed['margin-left'] + 'px';
         domNode.style.right = leavingBoundingBox.right - cleanedComputed['margin-right'] + 'px';
       });
+
+      const newHeight = this.props.getPosition(this.parentElement).height;
+      const collapseHeight = this.parentBox.height - newHeight;
+      this.leavingPaddingElement.style.height = collapseHeight + 'px';
     }
 
     const dynamicChildren = this.state.children.filter(
@@ -472,6 +474,8 @@ class FlipMove extends Component {
           );
         }
       });
+
+      this.leavingPaddingElement.style.height = 0;
     }
   }
 
@@ -483,24 +487,18 @@ class FlipMove extends Component {
       return React.cloneElement(child, { ref: child.key });
     });
 
-    // Sum the height of all boxes leaving the document flow.
-    const leavingHeight = children.reduce( (height, child) => {
-      return child.leaving
-        ? height + this.boundingBoxes[child.key].height
-        : height;
-    }, 0)
+    if ( this.props.leaveAnimation ) {
 
-    // If elements are indeed disappearing then create an invisible child
-    // element at the end of the list whose height will prevent the
-    // container from collapsing prematurely.
-    if (leavingHeight > 0) {
+      // Create an invisible child element at the end of the list whose height
+      // will prevent the container from collapsing prematurely.
       childNodes.push(
         <div
           key='leaving-padding'
+          ref={element => this.leavingPaddingElement = element}
           style={{
             // This should be `visibility: hidden` - blue is just for review.
             background: 'blue',
-            height: leavingHeight
+            height: 0
           }}
         />
       );

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -163,7 +163,8 @@ function propConverter(ComposedComponent) {
                               PropTypes.object
                             ]),
       getPosition:          PropTypes.func,
-      };
+      maintainContainerHeight: PropTypes.bool.isRequired,
+    };
 
 
     static defaultProps = {
@@ -176,6 +177,7 @@ function propConverter(ComposedComponent) {
       enterAnimation:     defaultPreset,
       leaveAnimation:     defaultPreset,
       getPosition:        node => node.getBoundingClientRect(),
+      maintainContainerHeight: false,
     };
   }
 }

--- a/stories/index.js
+++ b/stories/index.js
@@ -141,6 +141,9 @@ storiesOf('FlipMove', module)
 
     return <HandleEmpty />
   })
+  .add('maintain container height', () => (
+    <Controls maintainContainerHeight={true} style={{border: 'solid 2px magenta'}} />
+  ))
 
 function getPosition(node) {
   const rect = node.getBoundingClientRect();

--- a/stories/index.js
+++ b/stories/index.js
@@ -142,7 +142,11 @@ storiesOf('FlipMove', module)
     return <HandleEmpty />
   })
   .add('maintain container height', () => (
-    <Controls maintainContainerHeight={true} style={{border: 'solid 2px magenta'}} />
+    <Controls
+      maintainContainerHeight={true}
+      style={{border: 'solid 2px magenta'}}
+      childOuterStyles={{ margin: '20px' }}
+    />
   ))
 
 function getPosition(node) {
@@ -168,7 +172,9 @@ const items = [
 class Controls extends Component {
   static defaultProps = {
     firstChildOuterStyles: {},
-    firstChildInnerStyles: {}
+    firstChildInnerStyles: {},
+    childInnerStyles: {},
+    childOuterStyles: {},
   };
 
   constructor() {
@@ -230,8 +236,8 @@ class Controls extends Component {
 
     return this.state.items.map( (item, i) => {
       // Make a working copy of styles
-      let stylesOuterCopy = { ...stylesOuter };
-      let stylesInnerCopy = { ...stylesInner };
+      let stylesOuterCopy = { ...stylesOuter, ...this.props.childOuterStyles };
+      let stylesInnerCopy = { ...stylesInner, ...this.props.childInnerStyles };
 
       if ( this.props.styleFirstChild && item.name === 'Potent Potables' ) {
         stylesOuterCopy = {

--- a/stories/index.js
+++ b/stories/index.js
@@ -144,7 +144,7 @@ storiesOf('FlipMove', module)
   .add('maintain container height', () => (
     <Controls
       maintainContainerHeight={true}
-      style={{border: 'solid 2px magenta'}}
+      style={{border: 'solid 2px magenta', padding: '7px' }}
       childOuterStyles={{ margin: '20px' }}
     />
   ))

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -42,6 +42,7 @@ describe('FlipMove', () => {
         staggerDelayBy: 0,
         staggerDurationBy: 0,
         disableAllAnimations: false,
+        maintainContainerHeight: false,
         articles
       };
       this.count = 0;
@@ -67,6 +68,7 @@ describe('FlipMove', () => {
             staggerDelayBy={this.state.staggerDelayBy}
             staggerDurationBy={this.state.staggerDurationBy}
             disableAllAnimations={this.state.disableAllAnimations}
+            maintainContainerHeight={this.state.maintainContainerHeight}
             onStart={::this.onStartHandler}
             onFinish={::this.onFinishHandler}
             onFinishAll={finishAllStub}
@@ -279,7 +281,31 @@ describe('FlipMove', () => {
     });
 
   });
+
+  describe('container height', () => {
+    let containerBox = null;
+
+    before( () => {
+      containerBox = getContainerBox(renderedComponent)
+
+      renderedComponent.setState({
+        maintainContainerHeight: true,
+        articles: articles.slice(-1)
+      });
+    })
+
+    it('should be maintained', () => {
+      expect(containerBox.height).to.equal(getContainerBox(renderedComponent).height);
+    })
+  })
 });
+
+function getContainerBox(renderedComponent) {
+  const container = TestUtils.findRenderedDOMComponentWithTag(
+    renderedComponent, 'ul'
+  );
+  return container.getBoundingClientRect();
+}
 
 function getTagPositions(renderedComponent) {
   const outputTags = TestUtils.scryRenderedDOMComponentsWithTag(


### PR DESCRIPTION
Implementation inspired by discussions in #80. Handles variable margins, various box-sizing values and interruptions (synchronous "leaving" animations).

Added test and storybook page as requested.

Shortcomings/possible extensions:
- Does nothing for horizontal lists.
- Doesn't allow animation of container height.
- Always creates a `div` element - regardless of parent container. (this is technically not valid HTML if the parent is a `ul`, but I didn't sweat it too much because the tests already put `li` elements in a `div` which is also invalid...)

There's obviously more to do here to make it "right" - but for now this solves my immediate use case and feels like a step in the right direction. I called the prop `maintainContainerHeight` (instead of the suggested `maintainContainerSize`) because it doesn't maintain width.

Closes #80