### PR TITLE
Prevent error with HTMLElement when not redering from browser

### DIFF
--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -183,8 +183,10 @@ export const updateHeightPlaceholder = ({
 };
 
 export const getNativeNode = (element) => {
+  var isBrowser = typeof HTMLElement !== 'undefined';
+
   // `element` may already be a native node.
-  if (element instanceof HTMLElement) {
+  if (isBrowser && element instanceof HTMLElement) {
     return element;
   }
 


### PR DESCRIPTION
A change in the latest version is causing server rendering (or testing, in my case) to fail because of `HTMLElement` being undefined.

Added a simple check for that.