### PR TITLE
minor change to example custom animation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,26 +172,29 @@ You can supply your own CSS-based transitions to customize the behaviour. Both `
 ![Custom](https://s3.amazonaws.com/githubdocs/fm-custom-rotate-x.gif)
 
 ```js
-<FlipMove
-  staggerDelayBy={50}
-  enterAnimation={{
-    from: {
-      transform: 'rotateX(135deg)'
-    },
-    to: {
-      transform: ''
-    }
-  }}
-  leaveAnimation={{
-    from: {
-      transform: ''
-    },
-    to: {
-      transform: 'rotateX(-120deg)',
-      opacity: 0.6
-    }
-  }}
-/>
+ <FlipMove
+   staggerDelayBy={150}
+   enterAnimation={{
+     from: {
+       transform: 'rotateX(180deg)',
+       opacity: 0.1,
+     },
+     to: {
+       transform: '',
+     },
+   }}
+   leaveAnimation={{
+     from: {
+        transform: '',
+     },
+     to: {
+       transform: 'rotateX(-120deg)',
+       opacity: 0.1,
+     },
+   }}
+ >
+   {this.renderRows()}
+ </FlipMove>
 ```
 
 


### PR DESCRIPTION
I liked this custom animation a lot, but found that it caused weird 'hangs' at the beginning and end of animations when sorting multiple items per transition. By making these changes, the transitions are greatly smoothed out and much more pleasing to the eye. I also changed the format just a little so that its more common usage pattern is a little more obvious.