### PR TITLE
Fix case where there is no childrenData for a child prop

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -393,7 +393,9 @@ class FlipMove extends Component {
     this.props.children.forEach((child) => {
       // It is possible that a child does not have a `key` property;
       // Ignore these children, they don't need to be moved.
-      if (!child.key) {
+      // It is also possible that there is no childrenData for the key;
+      // Also ignore these.
+      if (!child.key || !this.childrenData[child.key]) {
         return;
       }
 


### PR DESCRIPTION
I was hitting a case where I had a child in the props' children, that did not have any data in the childrenData. I was having trouble tracking down how it got into that state. I have multiple nested flipmove instances, so that might have something to do with it. I thought I'd try just preventing it from blowing up and everything seemed to work correctly afterwards.

The error was occurring in getRelativeBoundingBox, when childData was undefined.