### PR TITLE
When not animating, allow the children to update.

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -114,7 +114,10 @@ class FlipMove extends Component {
     // IMPORTANT: We need to make sure that the children have actually changed.
     // At the end of the transition, we clean up nodes that need to be removed.
     // We DON'T want this cleanup to trigger another update.
-    const shouldTriggerFLIP = this.props.children !== previousProps.children;
+    const shouldTriggerFLIP = (
+      this.props.children !== previousProps.children &&
+      !this.isAnimationDisabled()
+    );
 
     if (shouldTriggerFLIP) {
       this.prepForAnimation();

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -101,7 +101,7 @@ class FlipMove extends Component {
     // Essentially, we want to keep just-deleted nodes in the DOM for a bit
     // longer, so that we can animate them away.
     const newChildren = this.isAnimationDisabled()
-      ? this.props.children
+      ? nextProps.children
       : this.calculateNextSetOfChildren(nextProps.children);
 
     this.setState({ children: newChildren });


### PR DESCRIPTION
If animation is disabled, allow the children to update from the new props.

I am turning animation off for a few different user actions. While it is turned off, any changes to the children are rendered one prop change behind. A forceUpdate triggers it to get up to date.

For example, with animation disabled:
Start with children A, B;
Add child C;
FlipMove will still show A, B;
Add child D;
FlipMove will now show A, B, C;

I think this also resolves pull request 91.