### PR TITLE
Remove references to nodes that have left

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -348,10 +348,10 @@ class FlipMove extends Component {
           const [elements, domNodes] = this.formatChildrenForHooks();
 
           this.props.onFinishAll(elements, domNodes);
-
-          // Reset our variables for the next iteration
-          this.childrenToAnimate = [];
         }
+
+        // Reset our variables for the next iteration
+        this.childrenToAnimate = [];
       });
 
       // If the placeholder was holding the container open while elements were

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -319,6 +319,7 @@ class FlipMove extends Component {
       this.triggerFinishHooks(child, domNode);
 
       domNode.removeEventListener(transitionEnd, transitionEndHandler);
+      if (child.leaving) delete this.childrenData[child.key];
     };
 
     domNode.addEventListener(transitionEnd, transitionEndHandler);


### PR DESCRIPTION
These two commits fix the following issues:
1) `this.childrenToAnimate` is only reset if you have a `onFinishAll` hook, which makes the list grow forever if you don't define one.
2) Children that have been animated away are still referenced by `this.childrenData`, preventing the browser from garbage collecting them.