### PR TITLE
Allows to have no children (fix #99)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,10 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
 export const isElementAnSFC = (element) => {
-  // account for null/undefined/false children.
-  if (!element) {
-    return false;
-  }
-
   const isNativeDOMElement = typeof element.type === 'string';
 
   if (isNativeDOMElement) {

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -35,7 +35,10 @@ function propConverter(ComposedComponent) {
       // Check to see if any supplied components won't work.
       // If the child doesn't have a key, it means we aren't animating it.
       // It's allowed to be an SFC, since we ignore it.
-      const noStateless = props.children.every(child =>
+      // Note: React.Children.toArray(...) takes care of corner cases like
+      // no children or 'falsy' children
+      const newChildren = React.Children.toArray(props.children);
+      const noStateless = newChildren.every(child =>
          !isElementAnSFC(child) || typeof child.key === 'undefined'
       );
 
@@ -76,7 +79,7 @@ function propConverter(ComposedComponent) {
       // This is to ensure we're always working with an array, and not
       // an only child. There's some weirdness with this.
       // See: https://github.com/facebook/react/pull/3650/files
-      workingProps.children = React.Children.toArray(this.props.children);
+      workingProps.children = newChildren;
 
       // Our enter/leave animations can be specified as boolean (default or
       // disabled), string (preset name), or object (actual animation values).


### PR DESCRIPTION
This commit should fix issue #99 since `React.Children.toArray` already take care of "corner cases".