### PR TITLE
Feature/graceful interrupts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "0.13.x || 0.14.x || 15.x.x"
   },
   "devDependencies": {
-    "@kadira/storybook": "1.19.0",
+    "@kadira/storybook": "2.30.1",
     "babel": "6.1.18",
     "babel-cli": "6.2.0",
     "babel-core": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flip-move",
-  "version": "2.6.10",
+  "version": "2.7.0-beta1",
   "description": "Effortless animation between DOM changes (eg. list reordering) using the FLIP technique.",
   "main": "lib/index.js",
   "files": [

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -398,6 +398,12 @@ class FlipMove extends Component {
     );
 
     this.props.children.forEach((child) => {
+      // It is possible that a child does not have a `key` property;
+      // Ignore these children, they don't need to be moved.
+      if (!child.key) {
+        return;
+      }
+
       // In very rare circumstances, for reasons unknown, the ref is never
       // populated for certain children. In this case, avoid doing this update.
       // see: https://github.com/joshwcomeau/react-flip-move/pull/91
@@ -405,16 +411,20 @@ class FlipMove extends Component {
         return;
       }
 
-      // It is possible that a child does not have a `key` property;
-      // Ignore these children, they don't need to be moved.
-      if (!child.key) {
-        return;
-      }
-
       this.childrenData[child.key].boundingBox = getRelativeBoundingBox({
         childData: this.childrenData[child.key],
         parentData: this.parentData,
         getPosition: this.props.getPosition,
+      });
+
+      // Once the child is updated, its `transform` property should be unset.
+      // This is so that if we're mid-transition, the current transition doesn't
+      // affect the calculations. This is how to ensure smooth interrupts
+      applyStylesToDOMNode({
+        domNode: this.childrenData[child.key].domNode,
+        styles: {
+          transition: '',
+        },
       });
     });
   }
@@ -444,6 +454,7 @@ class FlipMove extends Component {
         parentData: this.parentData,
         getPosition: this.props.getPosition,
       });
+
       style.transform = `translate(${dX}px, ${dY}px)`;
     }
 
@@ -483,6 +494,9 @@ class FlipMove extends Component {
     if (isEnteringWithAnimation || isLeavingWithAnimation) {
       return true;
     }
+
+    // TEMP
+    return true;
 
     // If it isn't entering/leaving, we want to animate it if it's
     // on-screen position has changed.

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -84,19 +84,18 @@ export const getPositionDelta = ({
   // remain. Until this bug can be solved, this band-aid fix does the job:
   const defaultBox = { left: 0, top: 0 };
 
-  // Our new box is the new final resting place: Where we expect it to wind up
-  // after the animation.
-  const newBoundingBox = getPosition(childData.domNode);
-
-  // debugger;
-
   // Our old box is its last calculated position, derived on mount or at the
   // start of the previous animation.
   const oldRelativeBox = childData.boundingBox || defaultBox;
 
+  // Our new box is the new final resting place: Where we expect it to wind up
+  // after the animation. First we get the box in absolute terms (AKA relative
+  // to the viewport), and then we calculate its relative box (relative to the
+  // parent container)
+  const newAbsoluteBox = getPosition(childData.domNode);
   const newRelativeBox = {
-    top: newBoundingBox.top - parentData.boundingBox.top,
-    left: newBoundingBox.left - parentData.boundingBox.left,
+    top: newAbsoluteBox.top - parentData.boundingBox.top,
+    left: newAbsoluteBox.left - parentData.boundingBox.left,
   };
 
   return [

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -84,17 +84,24 @@ export const getPositionDelta = ({
   // remain. Until this bug can be solved, this band-aid fix does the job:
   const defaultBox = { left: 0, top: 0 };
 
+  // Our new box is the new final resting place: Where we expect it to wind up
+  // after the animation.
   const newBoundingBox = getPosition(childData.domNode);
-  const oldBoundingBox = childData.boundingBox || defaultBox;
 
-  const relativeBox = {
+  // debugger;
+
+  // Our old box is its last calculated position, derived on mount or at the
+  // start of the previous animation.
+  const oldRelativeBox = childData.boundingBox || defaultBox;
+
+  const newRelativeBox = {
     top: newBoundingBox.top - parentData.boundingBox.top,
     left: newBoundingBox.left - parentData.boundingBox.left,
   };
 
   return [
-    oldBoundingBox.left - relativeBox.left,
-    oldBoundingBox.top - relativeBox.top,
+    oldRelativeBox.left - newRelativeBox.left,
+    oldRelativeBox.top - newRelativeBox.top,
   ];
 };
 

--- a/stories/helpers/FlipMoveListItem.js
+++ b/stories/helpers/FlipMoveListItem.js
@@ -4,10 +4,10 @@ import React, { Component, PropTypes } from 'react';
 // eslint-disable-next-line react/prefer-stateless-function
 class FlipMoveListItem extends Component {
   render() {
-    const { style, children } = this.props;
+    const { style, id, children } = this.props;
 
     return (
-      <div style={style}>
+      <div style={style} id={id}>
         {children}
       </div>
     );
@@ -16,6 +16,7 @@ class FlipMoveListItem extends Component {
 
 FlipMoveListItem.propTypes = {
   children: PropTypes.string,
+  id: PropTypes.string,
   // eslint-disable-next-line react/forbid-prop-types
   style: PropTypes.object,
 };

--- a/stories/helpers/FlipMoveWrapper.js
+++ b/stories/helpers/FlipMoveWrapper.js
@@ -81,6 +81,7 @@ class FlipMoveWrapper extends Component {
         this.props.itemType,
         {
           key: item.id,
+          id: item.id,
           style: {
             ...baseStyles.listItemStyles,
             ...this.props.listItemStyles,

--- a/stories/helpers/FlipMoveWrapper.js
+++ b/stories/helpers/FlipMoveWrapper.js
@@ -13,6 +13,7 @@ const baseStyles = {
   },
   flipMoveContainerStyles: { paddingTop: '20px' },
   listItemStyles: {
+    position: 'relative',
     fontFamily: '"Helvetica Neue", "San Francisco", sans-serif',
     padding: '10px',
     background: '#FFFFFF',
@@ -85,6 +86,7 @@ class FlipMoveWrapper extends Component {
           style: {
             ...baseStyles.listItemStyles,
             ...this.props.listItemStyles,
+            // zIndex: item.id.charCodeAt(0),
           },
         },
         item.text


### PR DESCRIPTION
* Shuffle interrupts are now handled gracefully in Chrome & Safari. Firefox remains unchanged, and I haven't tested IE/edge.
* Leave animation interrupts should be fixed. It's still a little glitchy in very elaborate scenarios with very long transition times, but sequentially removing several items in a row works. Miles better than the 'restarts-on-every-change' behaviour currently implemented.
* Update React Storybook