### PR TITLE
removed lodash.omit dependency which shaves off ~6.5kb of min+gzip size

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,5 @@
     "sinon-chai": "2.8.0",
     "style-loader": "0.13.1",
     "webpack": "1.12.11"
-  },
-  "dependencies": {
-    "lodash.omit": "4.3.0"
   }
 }

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -12,7 +12,6 @@
  */
 
 import React, { Component, PropTypes } from 'react';
-import omit from 'lodash.omit';
 
 import {
   statelessFunctionalComponentSupplied,
@@ -25,6 +24,15 @@ import {
 } from './enter-leave-presets';
 import { isElementAnSFC } from './helpers';
 
+function omit(obj, attrs = []) {
+  const result = {};
+  Object.keys(obj).forEach((key) => {
+    if (attrs.indexOf(key) === -1) {
+      result[key] = obj[key];
+    }
+  });
+  return result;
+}
 
 function propConverter(ComposedComponent) {
   class FlipMovePropConverter extends Component {
@@ -106,7 +114,7 @@ function propConverter(ComposedComponent) {
         ...delegatedProps.style,
       };
 
-      workingProps = omit(workingProps, delegatedProps);
+      workingProps = omit(workingProps, Object.keys(delegatedProps));
       workingProps.delegated = delegatedProps;
 
       return workingProps;


### PR DESCRIPTION
Hi Joshua! We've been loving this module thanks for sharing it! I'm doing a bit of bundle analysis of our app and noticed that this included lodash.omit which, as it turns out, also has several sub dependencies and ends up adding a surprising (at least to me) 6.5kb to the gzipped/minified size by my measurements. 

Given that `omit` is fairly simple in concept, I thought it'd may be worthwhile to inline a little `omit` implementation and send it your way for feedback.

Thanks again for this slick module!