### PR TITLE
Fix weird animation when inside component get change by set while animating

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -21,7 +21,7 @@ import {
   updateHeightPlaceholder,
   whichTransitionEvent,
 } from './dom-manipulation';
-import { arraysEqual } from './helpers'
+import { arraysEqual } from './helpers';
 
 const transitionEnd = whichTransitionEvent();
 const noBrowserSupport = !transitionEnd;
@@ -110,8 +110,8 @@ class FlipMove extends Component {
     // At the end of the transition, we clean up nodes that need to be removed.
     // We DON'T want this cleanup to trigger another update.
 
-    const oldChildrenKeys = this.props.children.map(d => d.key)
-    const nextChildrenKeys = previousProps.children.map(d => d.key)
+    const oldChildrenKeys = this.props.children.map(d => d.key);
+    const nextChildrenKeys = previousProps.children.map(d => d.key);
 
     const shouldTriggerFLIP = (
       !arraysEqual(oldChildrenKeys, nextChildrenKeys) &&

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -21,6 +21,7 @@ import {
   updateHeightPlaceholder,
   whichTransitionEvent,
 } from './dom-manipulation';
+import { arraysEqual } from './helpers'
 
 const transitionEnd = whichTransitionEvent();
 const noBrowserSupport = !transitionEnd;
@@ -108,8 +109,12 @@ class FlipMove extends Component {
     // IMPORTANT: We need to make sure that the children have actually changed.
     // At the end of the transition, we clean up nodes that need to be removed.
     // We DON'T want this cleanup to trigger another update.
+
+    const oldChildrenKeys = this.props.children.map(d => d.key)
+    const nextChildrenKeys = previousProps.children.map(d => d.key)
+
     const shouldTriggerFLIP = (
-      this.props.children !== previousProps.children &&
+      !arraysEqual(oldChildrenKeys, nextChildrenKeys) &&
       !this.isAnimationDisabled(this.props)
     );
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,3 +18,17 @@ export function omit(obj, attrs = []) {
   });
   return result;
 }
+
+export function arraysEqual(a, b) {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length != b.length) return false;
+
+  // If you don't care about the order of the elements inside
+  // the array, you should sort both arrays here.
+
+  for (var i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,15 +20,17 @@ export function omit(obj, attrs = []) {
 }
 
 export function arraysEqual(a, b) {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
-
-  // If you don't care about the order of the elements inside
-  // the array, you should sort both arrays here.
-
-  for (var i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) return false;
+  const sameObject = a === b;
+  if (sameObject) {
+    return true;
   }
-  return true;
+
+  const notBothArrays = !Array.isArray(a) || !Array.isArray(b);
+  const differentLengths = a.length !== b.length;
+
+  if (notBothArrays || differentLengths) {
+    return false;
+  }
+
+  return a.every((element, index) => element === b[index]);
 }

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -68,3 +68,9 @@ if (!Array.prototype.every) {
     return true;
   };
 }
+
+if (!Array.isArray) {
+  Array.isArray = function(arg) {
+    return Object.prototype.toString.call(arg) === '[object Array]';
+  };
+}

--- a/stories/enter-leave-animations.stories.js
+++ b/stories/enter-leave-animations.stories.js
@@ -13,6 +13,12 @@ import FlipMoveListItem from './helpers/FlipMoveListItem';
         itemType={type}
       />
     ))
+    .add('default (elevator preset) with constantly change item', () => (
+      <FlipMoveWrapper
+        itemType={type}
+        changeItem
+      />
+    ))
     .add('preset - fade', () => (
       <FlipMoveWrapper
         itemType={type}

--- a/stories/enter-leave-animations.stories.js
+++ b/stories/enter-leave-animations.stories.js
@@ -16,7 +16,7 @@ import FlipMoveListItem from './helpers/FlipMoveListItem';
     .add('default (elevator preset) with constantly change item', () => (
       <FlipMoveWrapper
         itemType={type}
-        changeItem
+        applyContinuousItemUpdates
       />
     ))
     .add('preset - fade', () => (

--- a/stories/helpers/FlipMoveWrapper.js
+++ b/stories/helpers/FlipMoveWrapper.js
@@ -41,6 +41,12 @@ class FlipMoveWrapper extends Component {
     if (this.props.sequence) {
       this.runSequence();
     }
+    setInterval(() => {
+      const newItems = _.clone(this.state.items)
+      if (newItems.length === 0) return
+      newItems[0] = { ...newItems[0], count: newItems[0].count + 1 }
+      this.setState({ items: newItems })
+    } , 500)
   }
 
   restartSequence() {
@@ -182,7 +188,7 @@ FlipMoveWrapper.propTypes = {
 
 FlipMoveWrapper.defaultProps = {
   items: [
-    { id: 'a', text: "7 Insecticides You Don't Know You're Consuming" },
+    { id: 'a', text: "7 Insecticides You Don't Know You're Consuming", count: 0 },
     { id: 'b', text: '11 Ways To Style Your Hair' },
     { id: 'c', text: 'The 200 Countries You Have To Visit Before The Apocalypse' },
     { id: 'd', text: 'Turtles: The Unexpected Miracle Anti-Aging Product' },

--- a/stories/helpers/FlipMoveWrapper.js
+++ b/stories/helpers/FlipMoveWrapper.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { sample, shuffle } from 'lodash';
+import { sample, shuffle, clone } from 'lodash';
 
 import FlipMove from '../../src';
 import Controls from './Controls';
@@ -41,22 +41,27 @@ class FlipMoveWrapper extends Component {
     if (this.props.sequence) {
       this.runSequence();
     }
-    if (this.props.changeItem) {
-      this.constantlyChangeItem();
+    if (this.props.applyContinuousItemUpdates) {
+      this.updateCountOnInterval();
     }
   }
 
-  componentWillUnmount () {
-    clearInterval(this.runningInterval)
+  componentWillUnmount() {
+    clearInterval(this.runningInterval);
   }
 
-  constantlyChangeItem () {
+  updateCountOnInterval() {
     this.runningInterval = setInterval(() => {
-      const newItems = _.clone(this.state.items)
-      if (newItems.length === 0) return
-      newItems[0] = { ...newItems[0], count: newItems[0].count + 1 }
-      this.setState({ items: newItems })
-    } , 500)
+      const newItems = clone(this.state.items);
+
+      if (newItems.length === 0) {
+        return;
+      }
+
+      newItems[0] = { ...newItems[0], count: newItems[0].count + 1 };
+
+      this.setState({ items: newItems });
+    }, 250);
   }
 
   restartSequence() {
@@ -120,13 +125,21 @@ class FlipMoveWrapper extends Component {
   }
 
   renderItems() {
+    const { items } = this.state;
+
     // Support falsy children by passing them straight to FlipMove
-    if (!this.state.items) {
-      return this.state.items;
+    if (!items) {
+      return items;
     }
 
-    return this.state.items.map(item => (
-      React.createElement(
+    return items.map((item) => {
+      let text = item.text;
+
+      if (item.count) {
+        text += ` - Count: ${item.count}`;
+      }
+
+      return React.createElement(
         this.props.itemType,
         {
           key: item.id,
@@ -137,9 +150,9 @@ class FlipMoveWrapper extends Component {
             // zIndex: item.id.charCodeAt(0),
           },
         },
-        item.text + (this.props.changeItem ? `- Count: ${item.count}` : '')
-      )
-    ));
+        text
+      );
+    });
   }
 
   render() {
@@ -190,19 +203,21 @@ FlipMoveWrapper.propTypes = {
   bodyContainerStyles: PropTypes.object,
   flipMoveContainerStyles: PropTypes.object,
   listItemStyles: PropTypes.object,
+  applyContinuousItemUpdates: PropTypes.bool,
   sequence: PropTypes.arrayOf(PropTypes.shape({
     eventName: PropTypes.string,
     delay: PropTypes.number,
+    args: PropTypes.array,
   })),
 };
 
 FlipMoveWrapper.defaultProps = {
   items: [
     { id: 'a', text: "7 Insecticides You Don't Know You're Consuming", count: 0 },
-    { id: 'b', text: '11 Ways To Style Your Hair', count: 0  },
-    { id: 'c', text: 'The 200 Countries You Have To Visit Before The Apocalypse', count: 0  },
-    { id: 'd', text: 'Turtles: The Unexpected Miracle Anti-Aging Product', count: 0  },
-    { id: 'e', text: 'Divine Intervention: Fashion Tips For The Vatican', count: 0  },
+    { id: 'b', text: '11 Ways To Style Your Hair', count: 0 },
+    { id: 'c', text: 'The 200 Countries You Have To Visit Before The Apocalypse', count: 0 },
+    { id: 'd', text: 'Turtles: The Unexpected Miracle Anti-Aging Product', count: 0 },
+    { id: 'e', text: 'Divine Intervention: Fashion Tips For The Vatican', count: 0 },
   ],
   itemType: 'div',
 };

--- a/stories/helpers/FlipMoveWrapper.js
+++ b/stories/helpers/FlipMoveWrapper.js
@@ -41,7 +41,17 @@ class FlipMoveWrapper extends Component {
     if (this.props.sequence) {
       this.runSequence();
     }
-    setInterval(() => {
+    if (this.props.changeItem) {
+      this.constantlyChangeItem();
+    }
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.runningInterval)
+  }
+
+  constantlyChangeItem () {
+    this.runningInterval = setInterval(() => {
       const newItems = _.clone(this.state.items)
       if (newItems.length === 0) return
       newItems[0] = { ...newItems[0], count: newItems[0].count + 1 }
@@ -127,7 +137,7 @@ class FlipMoveWrapper extends Component {
             // zIndex: item.id.charCodeAt(0),
           },
         },
-        item.text
+        item.text + (this.props.changeItem ? `- Count: ${item.count}` : '')
       )
     ));
   }
@@ -189,10 +199,10 @@ FlipMoveWrapper.propTypes = {
 FlipMoveWrapper.defaultProps = {
   items: [
     { id: 'a', text: "7 Insecticides You Don't Know You're Consuming", count: 0 },
-    { id: 'b', text: '11 Ways To Style Your Hair' },
-    { id: 'c', text: 'The 200 Countries You Have To Visit Before The Apocalypse' },
-    { id: 'd', text: 'Turtles: The Unexpected Miracle Anti-Aging Product' },
-    { id: 'e', text: 'Divine Intervention: Fashion Tips For The Vatican' },
+    { id: 'b', text: '11 Ways To Style Your Hair', count: 0  },
+    { id: 'c', text: 'The 200 Countries You Have To Visit Before The Apocalypse', count: 0  },
+    { id: 'd', text: 'Turtles: The Unexpected Miracle Anti-Aging Product', count: 0  },
+    { id: 'e', text: 'Divine Intervention: Fashion Tips For The Vatican', count: 0  },
   ],
   itemType: 'div',
 };


### PR DESCRIPTION
Right now, if you try to change some component inside FlipMove while animation is running, it will cause a weird animation as stated in "Known Issues"

This happen because when component inside FilpMove changes, it will try to re-calculate animating components in `runAnimation` method again via `componentDidUpdate` and store into `remainingAnimations`. And if animation is already running, it will doubled up `remainingAnimations` count.

I workaround that by instead of comparing children in each prop directly, I compare children key equality. So if the children is the same set, FlipMove should not rerun animation.