### PR TITLE
Make sure the transition end handler gets called, even if the browser event does not fire.

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -314,15 +314,20 @@ class FlipMove extends Component {
 
   bindTransitionEndHandler(child) {
     const { domNode } = this.childrenData[child.key];
+    const {duration} = this.props;
+    let ended = false;
 
     // The onFinish callback needs to be bound to the transitionEnd event.
     // We also need to unbind it when the transition completes, so this ugly
     // inline function is required (we need it here so it closes over
     // dependent variables `child` and `domNode`)
-    const transitionEndHandler = (ev) => {
-      // It's possible that this handler is fired not on our primary transition,
-      // but on a nested transition (eg. a hover effect). Ignore these cases.
-      if (ev.target !== domNode) return;
+    const onTransitionEnd = () => {
+      //Make sure we don't get called twice
+      if (ended) {
+        return;
+      }
+
+      ended = true;
 
       // Remove the 'transition' inline style we added. This is cleanup.
       domNode.style.transition = '';
@@ -330,14 +335,22 @@ class FlipMove extends Component {
       // Trigger any applicable onFinish/onFinishAll hooks
       this.triggerFinishHooks(child, domNode);
 
-      domNode.removeEventListener(transitionEnd, transitionEndHandler);
-
       if (child.leaving) {
         delete this.childrenData[child.key];
+      }
+    }
+
+    const transitionEndHandler = (ev) => {
+      // It's possible that this handler is fired not on our primary transition,
+      // but on a nested transition (eg. a hover effect). Ignore these cases.
+      if (ev.target === domNode) {
+        onTransitionEnd();
       }
     };
 
     domNode.addEventListener(transitionEnd, transitionEndHandler);
+    //Add the setTimeout just in-case the transition end doesn't fire
+    setTimeout(onTransitionEnd, duration + 100);
   }
 
   triggerFinishHooks(child, domNode) {


### PR DESCRIPTION
I was hitting a case where after passing a new set of children with some removed, the items that were suppose to be removed were still present. Upon further inspection the remainingAnimations property was still 1. Calling triggerFinishHooks manually seems to fix it.

My assumption was that somehow one item wasn't getting the transition end handler called, so I tried making sure that we call transitionEndHandler.

With that change I'm no longer seeing the original issue, granted it was happening sporadically.