### PR TITLE
Suppress warnings when in production

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -498,6 +498,7 @@ class FlipMove extends Component {
     };
   }
 
+  // eslint-disable-next-line class-methods-use-this
   isAnimationDisabled(props) {
     // If the component is explicitly passed a `disableAllAnimations` flag,
     // we can skip this whole process. Similarly, if all of the numbers have

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -10,6 +10,7 @@
  *     be, if a single child is passed in.)
  *   - Resolving animation presets into their base CSS styles
  */
+/* eslint-disable block-scoped-var */
 
 import React, { Component, PropTypes } from 'react';
 
@@ -28,10 +29,13 @@ import {
 } from './enter-leave-presets';
 import { isElementAnSFC, omit } from './helpers';
 
-// Define process global in case the consumer hasn't defined process.env.NODE_ENV
+// Define `process` global in case the consumer hasn't defined
+// process.env.NODE_ENV
+/* eslint-disable no-use-before-define, vars-on-top, no-var */
 if (typeof process === 'undefined') {
   var process = { env: {} };  // Must use var to escape block scoping
 }
+/* eslint-enable */
 
 function propConverter(ComposedComponent) {
   class FlipMovePropConverter extends Component {
@@ -72,7 +76,7 @@ function propConverter(ComposedComponent) {
 
         if (isNaN(value)) {
           const defaultValue = defaultProps[prop];
-          
+
           if (process.env.NODE_ENV !== 'production') {
             console.error(invalidTypeForTimingProp({
               prop,
@@ -105,7 +109,7 @@ function propConverter(ComposedComponent) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(deprecatedDisableAnimations());
         }
-        
+
         workingProps.disableAnimations = undefined;
         workingProps.disableAllAnimations = props.disableAnimations;
       }
@@ -154,7 +158,7 @@ function propConverter(ComposedComponent) {
                 defaultValue: defaultPreset,
               }));
             }
-            
+
             newAnimation = presets[defaultPreset];
           } else {
             newAnimation = presets[animation];

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -28,6 +28,10 @@ import {
 } from './enter-leave-presets';
 import { isElementAnSFC, omit } from './helpers';
 
+// Define process global in case the consumer hasn't defined process.env.NODE_ENV
+if (typeof process === 'undefined') {
+  var process = { env: {} };  // Must use var to escape block scoping
+}
 
 function propConverter(ComposedComponent) {
   class FlipMovePropConverter extends Component {
@@ -41,16 +45,18 @@ function propConverter(ComposedComponent) {
       // child is passed, as well as if the child is falsy.
       workingProps.children = React.Children.toArray(props.children);
 
-      // FlipMove does not support stateless functional components.
-      // Check to see if any supplied components won't work.
-      // If the child doesn't have a key, it means we aren't animating it.
-      // It's allowed to be an SFC, since we ignore it.
-      const noStateless = workingProps.children.every(child =>
-         !isElementAnSFC(child) || typeof child.key === 'undefined'
-      );
+      if (process.env.NODE_ENV !== 'production') {
+        // FlipMove does not support stateless functional components.
+        // Check to see if any supplied components won't work.
+        // If the child doesn't have a key, it means we aren't animating it.
+        // It's allowed to be an SFC, since we ignore it.
+        const noStateless = workingProps.children.every(child =>
+           !isElementAnSFC(child) || typeof child.key === 'undefined'
+        );
 
-      if (!noStateless) {
-        console.warn(statelessFunctionalComponentSupplied());
+        if (!noStateless) {
+          console.warn(statelessFunctionalComponentSupplied());
+        }
       }
 
       // Do string-to-int conversion for all timing-related props
@@ -66,12 +72,14 @@ function propConverter(ComposedComponent) {
 
         if (isNaN(value)) {
           const defaultValue = defaultProps[prop];
-          const errorMessage = invalidTypeForTimingProp({
-            prop,
-            value,
-            defaultValue,
-          });
-          console.error(errorMessage);
+          
+          if (process.env.NODE_ENV !== 'production') {
+            console.error(invalidTypeForTimingProp({
+              prop,
+              value,
+              defaultValue,
+            }));
+          }
 
           value = defaultValue;
         }
@@ -94,7 +102,10 @@ function propConverter(ComposedComponent) {
 
       // Accept `disableAnimations`, but add a deprecation warning
       if (typeof props.disableAnimations !== 'undefined') {
-        console.warn(deprecatedDisableAnimations());
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(deprecatedDisableAnimations());
+        }
+        
         workingProps.disableAnimations = undefined;
         workingProps.disableAllAnimations = props.disableAnimations;
       }
@@ -136,11 +147,14 @@ function propConverter(ComposedComponent) {
           const presetKeys = Object.keys(presets);
 
           if (presetKeys.indexOf(animation) === -1) {
-            console.error(invalidEnterLeavePreset({
-              value: animation,
-              acceptableValues: presetKeys.join(', '),
-              defaultValue: defaultPreset,
-            }));
+            if (process.env.NODE_ENV !== 'production') {
+              console.error(invalidEnterLeavePreset({
+                value: animation,
+                acceptableValues: presetKeys.join(', '),
+                defaultValue: defaultPreset,
+              }));
+            }
+            
             newAnimation = presets[defaultPreset];
           } else {
             newAnimation = presets[animation];

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -29,13 +29,15 @@ import {
 } from './enter-leave-presets';
 import { isElementAnSFC, omit } from './helpers';
 
+
 // Define `process` global in case the consumer hasn't defined
-// process.env.NODE_ENV
+// process.env.NODE_ENV. We use 'var' to escape block scoping.
 /* eslint-disable no-use-before-define, vars-on-top, no-var */
 if (typeof process === 'undefined') {
-  var process = { env: {} };  // Must use var to escape block scoping
+  var process = { env: {} };
 }
 /* eslint-enable */
+
 
 function propConverter(ComposedComponent) {
   class FlipMovePropConverter extends Component {


### PR DESCRIPTION
Prop converter does several runtime checks and logs warnings that aren't needed in production.  When `process.env.NODE_ENV === 'production'`, they are now disabled.