### PR TITLE
Deduplicate warnings

### DIFF
--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -1,42 +1,52 @@
 // @flow
 import type { Presets } from './typings';
 
-export const statelessFunctionalComponentSupplied = () => `
+function warn(msg: string) {
+  let hasWarned = false;
+  return () => {
+    if (!hasWarned) {
+      console.warn(msg);
+      hasWarned = true;
+    }
+  };
+}
+
+export const statelessFunctionalComponentSupplied = warn(`
 >> Error, via react-flip-move <<
 
 You provided a stateless functional component as a child to <FlipMove>. Unfortunately, SFCs aren't supported, because Flip Move needs access to the backing instances via refs, and SFCs don't have a public instance that holds that info.
 
 Please wrap your components in a native element (eg. <div>), or a non-functional component.
-`;
+`);
 
 export const invalidTypeForTimingProp = (args: {
   prop: string,
   value: string | number,
   defaultValue: number,
-}) => `
+}) => console.error(`
 >> Error, via react-flip-move <<
 
 The prop you provided for '${args.prop}' is invalid. It needs to be a positive integer, or a string that can be resolved to a number. The value you provided is '${args.value}'.
 
 As a result,  the default value for this parameter will be used, which is '${args.defaultValue}'.
-`;
+`);
 
-export const deprecatedDisableAnimations = () => `
+export const deprecatedDisableAnimations = warn(`
 >> Warning, via react-flip-move <<
 
 The 'disableAnimations' prop you provided is deprecated. Please switch to use 'disableAllAnimations'.
 
 This will become a silent error in future versions of react-flip-move.
-`;
+`);
 
 export const invalidEnterLeavePreset = (args: {
   value: string,
   acceptableValues: string,
   defaultValue: $Keys<Presets>,
-}) => `
+}) => console.error(`
 >> Error, via react-flip-move <<
 
 The enter/leave preset you provided is invalid. We don't currently have a '${args.value} preset.'
 
 Acceptable values are ${args.acceptableValues}. The default value of '${args.defaultValue}' will be used.
-`;
+`);

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Presets } from './typings';
 
-function warn(msg: string) {
+function warnOnce(msg: string) {
   let hasWarned = false;
   return () => {
     if (!hasWarned) {
@@ -11,7 +11,7 @@ function warn(msg: string) {
   };
 }
 
-export const statelessFunctionalComponentSupplied = warn(`
+export const statelessFunctionalComponentSupplied = warnOnce(`
 >> Error, via react-flip-move <<
 
 You provided a stateless functional component as a child to <FlipMove>. Unfortunately, SFCs aren't supported, because Flip Move needs access to the backing instances via refs, and SFCs don't have a public instance that holds that info.
@@ -31,7 +31,7 @@ The prop you provided for '${args.prop}' is invalid. It needs to be a positive i
 As a result,  the default value for this parameter will be used, which is '${args.defaultValue}'.
 `);
 
-export const deprecatedDisableAnimations = warn(`
+export const deprecatedDisableAnimations = warnOnce(`
 >> Warning, via react-flip-move <<
 
 The 'disableAnimations' prop you provided is deprecated. Please switch to use 'disableAllAnimations'.

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -93,7 +93,7 @@ function propConverter(
       );
 
       if (!noStateless) {
-        console.warn(statelessFunctionalComponentSupplied());
+        statelessFunctionalComponentSupplied();
       }
     }
 
@@ -139,7 +139,7 @@ function propConverter(
       // Accept `disableAnimations`, but add a deprecation warning
       if (typeof props.disableAnimations !== 'undefined') {
         if (nodeEnv !== 'production') {
-          console.warn(deprecatedDisableAnimations());
+          deprecatedDisableAnimations();
         }
 
         workingProps.disableAllAnimations = props.disableAnimations;
@@ -174,11 +174,11 @@ function propConverter(
         const defaultValue: number = FlipMovePropConverter.defaultProps[prop];
 
         if (nodeEnv !== 'production') {
-          console.error(invalidTypeForTimingProp({
+          invalidTypeForTimingProp({
             prop,
             value: rawValue,
             defaultValue,
-          }));
+          });
         }
 
         return defaultValue;
@@ -203,11 +203,11 @@ function propConverter(
 
           if (presetKeys.indexOf(animation) === -1) {
             if (nodeEnv !== 'production') {
-              console.error(invalidEnterLeavePreset({
+              invalidEnterLeavePreset({
                 value: animation,
                 acceptableValues: presetKeys.join(', '),
                 defaultValue: defaultPreset,
-              }));
+              });
             }
 
             return presets[defaultPreset];


### PR DESCRIPTION
While working on #153, I've noticed then when preact children are supplied, they generate false positive warnings about them being SFC. This is not a really big issue, but, to stop spoiling the console, I've added some deduplication, so that each type of warning fires only once