### PR TITLE
Hotfix: satisfy preact peerDependency to make storybook run

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "karma-webpack": "1.7.0",
     "lodash": "4.3.0",
     "mocha": "2.4.5",
+    "preact": "8.1.0",
     "preact-compat": "3.16.0",
     "prop-types": "15.5.8",
     "react": "15.5.4",


### PR DESCRIPTION
As @AlexanderOtavka has [pointed out](https://github.com/joshwcomeau/react-flip-move/pull/151#discussion_r116388826), `preact` is a peer dep of `preact-compact`. In fact, storybook-preact doesn't run without it:

```
ERROR in ./~/preact-compat/dist/preact-compat.js
Module not found: Error: Cannot resolve module 'preact' in /Users/jetbrains/react-flip-move/node_modules/preact-compat/dist
```