### PR TITLE
Extract public API typings into libdef

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Flip Move uses the [_FLIP technique_](https://aerotwist.com/blog/flip-your-anima
 * [Known Issues](#known-issues)
 * [Contributions](#contributions)
 * [Development](#development)
+* [Flow support](#flow-support)
 * [License](#license)
 
 
@@ -191,6 +192,21 @@ This project uses [React Storybook](https://github.com/kadirahq/react-storybook)
 
 After installing dependencies, launch the Storybook dev server with `npm run storybook`.
 
+## Flow support
+
+Flip Move's sources are type-checked with [Flow](https://flow.org/). If your project uses it too, you may want to install typings for our public API from [flow-typed](https://github.com/flowtype/flow-typed) repo.
+
+```bash
+npm install --global flow-typed # if not already
+flow-typed install react-flip-move@<version>
+```
+
+If you're getting some flow errors coming from `node_modules/react-flip-move/src` path, you should add this to your `.flowconfig` file:
+
+```
+[ignore]
+.*/node_modules/react-flip-move/.*
+```
 
 
 ## License

--- a/flow-typed/react-flip-move_v2.9.x.js
+++ b/flow-typed/react-flip-move_v2.9.x.js
@@ -1,0 +1,87 @@
+declare module 'react-flip-move' {
+  declare export type Styles = {
+    [key: string]: string,
+  };
+
+  declare type ReactStyles = {
+    [key: string]: string | number,
+  };
+
+  declare export type Animation = {
+    from: Styles,
+    to: Styles,
+  };
+
+  declare export type Presets = {
+    elevator: Animation,
+    fade: Animation,
+    accordionVertical: Animation,
+    accordionHorizontal: Animation,
+    none: null,
+  };
+
+  declare export type AnimationProp = $Keys<Presets> | boolean | Animation;
+
+  declare export type ClientRect = {
+    top: number,
+    right: number,
+    bottom: number,
+    left: number,
+    height: number,
+    width: number,
+  };
+
+  // can't use $Shape<React$Element<*>> here, because we use it in intersection
+  declare export type ElementShape = {
+    type: $PropertyType<React$Element<*>, 'type'>,
+    props: $PropertyType<React$Element<*>, 'props'>,
+    key: $PropertyType<React$Element<*>, 'key'>,
+    ref: $PropertyType<React$Element<*>, 'ref'>,
+  };
+
+  declare type ChildHook = (element: ElementShape, node: ?HTMLElement) => mixed;
+
+  declare export type ChildrenHook = (
+    elements: Array<ElementShape>,
+    nodes: Array<?HTMLElement>
+  ) => mixed;
+
+  declare export type GetPosition = (node: HTMLElement) => ClientRect;
+
+  declare export type VerticalAlignment = 'top' | 'bottom';
+
+  // this one cannot use intersection, see https://github.com/facebook/flow/issues/2904
+  declare export type FlipMoveDefaultProps = {
+    easing: string,
+    duration: string | number,
+    delay: string | number,
+    staggerDurationBy: string | number,
+    staggerDelayBy: string | number,
+    typeName: string,
+    enterAnimation: AnimationProp,
+    leaveAnimation: AnimationProp,
+    disableAllAnimations: boolean,
+    getPosition: GetPosition,
+    maintainContainerHeight: boolean,
+    verticalAlignment: VerticalAlignment,
+  };
+
+  declare export type Hooks = {
+    onStart?: ChildHook,
+    onFinish?: ChildHook,
+    onStartAll?: ChildrenHook,
+    onFinishAll?: ChildrenHook,
+  };
+
+  declare export type DelegatedProps = {
+    style?: ReactStyles,
+  };
+
+  declare export type FlipMoveProps = FlipMoveDefaultProps & Hooks & DelegatedProps & {
+    children?: mixed,
+    appearAnimation?: AnimationProp,
+    disableAnimations?: boolean, // deprecated, use disableAllAnimations instead
+  };
+
+  declare export default Class<React$Component<FlipMoveDefaultProps, FlipMoveProps, void>>;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "lint": "eslint src",
-    "build:lib": "babel src --out-dir lib && flow-copy-source -v src lib",
+    "build:lib": "babel src --out-dir lib",
     "build:umd": "webpack src/index.js dist/react-flip-move.js --config webpack.config.production.js",
     "build:umd:min": "webpack src/index.js dist/react-flip-move.min.js --config webpack.config.production.min.js",
     "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
@@ -68,7 +68,6 @@
     "eslint-plugin-react": "6.10.3",
     "eslint-plugin-sort-class-members": "1.1.1",
     "flow-bin": "0.45.0",
-    "flow-copy-source": "1.1.0",
     "flow-coverage-report": "0.3.0",
     "karma": "0.13.19",
     "karma-chai": "0.1.0",

--- a/src/typings.js
+++ b/src/typings.js
@@ -1,85 +1,35 @@
 // @flow
 import type { Element } from 'react';
+import type {
+  Styles,
+  Animation,
+  Presets,
+  AnimationProp,
+  ClientRect,
+  ElementShape,
+  ChildrenHook,
+  GetPosition,
+  VerticalAlignment,
+  FlipMoveDefaultProps,
+  Hooks,
+  DelegatedProps,
+  FlipMoveProps,
+} from 'react-flip-move'; // eslint-disable-line import/extensions
 
-export type Styles = {
-  [string]: string,
-};
-
-type ReactStyles = {
-  [string]: string | number,
-};
-
-export type Animation = {
-  from: Styles,
-  to: Styles,
-};
-
-export type Presets = {
-  elevator: Animation,
-  fade: Animation,
-  accordionVertical: Animation,
-  accordionHorizontal: Animation,
-  none: null,
-};
-
-export type AnimationProp = $Keys<Presets> | boolean | Animation;
-
-export type ClientRect = {
-  top: number,
-  right: number,
-  bottom: number,
-  left: number,
-  height: number,
-  width: number,
-};
-
-// can't use $Shape<Element<*>> here, because we use it in intersection
-export type ElementShape = {
-  type: $PropertyType<Element<*>, 'type'>,
-  props: $PropertyType<Element<*>, 'props'>,
-  key: $PropertyType<Element<*>, 'key'>,
-  ref: $PropertyType<Element<*>, 'ref'>,
-};
-
-type ChildHook = (ElementShape, ?HTMLElement) => mixed;
-
-export type ChildrenHook = (Array<ElementShape>, Array<?HTMLElement>) => mixed;
-
-export type GetPosition = (HTMLElement) => ClientRect;
-
-export type VerticalAlignment = 'top' | 'bottom';
-
-// this one cannot use intersection, see https://github.com/facebook/flow/issues/2904
-export type FlipMoveDefaultProps = {
-  easing: string,
-  duration: string | number,
-  delay: string | number,
-  staggerDurationBy: string | number,
-  staggerDelayBy: string | number,
-  typeName: string,
-  enterAnimation: AnimationProp,
-  leaveAnimation: AnimationProp,
-  disableAllAnimations: boolean,
-  getPosition: GetPosition,
-  maintainContainerHeight: boolean,
-  verticalAlignment: VerticalAlignment,
-};
-
-type Hooks = {
-  onStart?: ChildHook,
-  onFinish?: ChildHook,
-  onStartAll?: ChildrenHook,
-  onFinishAll?: ChildrenHook,
-};
-
-export type DelegatedProps = {
-  style?: ReactStyles,
-};
-
-export type FlipMoveProps = FlipMoveDefaultProps & Hooks & DelegatedProps & {
-  children?: mixed,
-  appearAnimation?: AnimationProp,
-  disableAnimations?: boolean, // deprecated, use disableAllAnimations instead
+export type {
+  Styles,
+  Animation,
+  Presets,
+  AnimationProp,
+  ClientRect,
+  ElementShape,
+  ChildrenHook,
+  GetPosition,
+  VerticalAlignment,
+  FlipMoveDefaultProps,
+  Hooks,
+  DelegatedProps,
+  FlipMoveProps,
 };
 
 export type ConvertedProps = Hooks & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1507,7 +1507,7 @@ camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^2.0.0, camelcase@^2.0.1:
+camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
@@ -1626,7 +1626,7 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-cliui@^3.0.3, cliui@^3.2.0:
+cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
   dependencies:
@@ -2678,15 +2678,6 @@ flow-bin@0.45.0:
   version "0.45.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
 
-flow-copy-source@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-1.1.0.tgz#0779692ff81693d304021b2d49753898a0772237"
-  dependencies:
-    fs-extra "^0.26.5"
-    glob "^7.0.0"
-    kefir "^3.2.0"
-    yargs "^3.32.0"
-
 flow-coverage-report@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/flow-coverage-report/-/flow-coverage-report-0.3.0.tgz#a22d52fc9fa9c24ae0be02712a6fe1ac156f0d93"
@@ -2749,16 +2740,6 @@ fs-access@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
   dependencies:
     null-check "^1.0.0"
-
-fs-extra@^0.26.5:
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
 
 fs-readdir-recursive@^0.1.0:
   version "0.1.2"
@@ -2919,7 +2900,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3425,12 +3406,6 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3524,12 +3499,6 @@ karma@0.13.19:
     source-map "^0.5.3"
     useragent "^2.1.6"
 
-kefir@^3.2.0:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.7.1.tgz#e77f56feeec46f4a2ee2997e5c3226e904877b5b"
-  dependencies:
-    symbol-observable "^1.0.1"
-
 keycode@^2.1.1:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.8.tgz#94d2b7098215eff0e8f9a8931d5a59076c4532fb"
@@ -3539,12 +3508,6 @@ kind-of@^3.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
     is-buffer "^1.0.2"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -5502,7 +5465,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.2:
+symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -5901,10 +5864,6 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-window-size@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
-
 window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
@@ -5971,7 +5930,7 @@ xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-y18n@^3.2.0, y18n@^3.2.1:
+y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
@@ -6000,18 +5959,6 @@ yargs@5.0.0:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^3.2.0"
-
-yargs@^3.32.0:
-  version "3.32.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
-  dependencies:
-    camelcase "^2.0.1"
-    cliui "^3.0.3"
-    decamelize "^1.1.1"
-    os-locale "^1.4.0"
-    string-width "^1.0.1"
-    window-size "^0.1.4"
-    y18n "^3.2.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Should partially fix #157. The `react-flip-move_v2.9.x.js` file is exactly the same as the one commited in https://github.com/flowtype/flow-typed/pull/844, and they have to stay in sync. Ideally they shouldn't be touched though, unless a minor version comes and brings some new API