### PR TITLE
Workaround for Zombie DOM Nodes

### DIFF
--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -169,6 +169,7 @@ export const removeNodeFromDOMFlow = (
 
   const styles: Styles = {
     position: 'absolute',
+    zIndex: -1,
     top: `${topOffset - margins['margin-top']}px`,
     left: `${boundingBox.left - margins['margin-left']}px`,
     right: `${boundingBox.right - margins['margin-right']}px`,

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -169,7 +169,7 @@ export const removeNodeFromDOMFlow = (
 
   const styles: Styles = {
     position: 'absolute',
-    zIndex: -1,
+    zIndex: '-1',
     top: `${topOffset - margins['margin-top']}px`,
     left: `${boundingBox.left - margins['margin-left']}px`,
     right: `${boundingBox.right - margins['margin-right']}px`,

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -11,39 +11,141 @@ const items = [
   { name: 'Potent Potables' },
   { name: 'The Pen is Mightier' },
   { name: 'Famous Horsemen' },
-  { name: 'A Petit Déjeuner' }
-]
+  { name: 'A Petit Déjeuner' },
+];
 
 storiesOf('Github Issues', module)
-  .add('#31', () => (
-    <Controls duration={400} />
-  ))
-  .add('#141' , () => {
+  .add('#31', () => <Controls duration={400} />)
+  .add('#120', () => {
+    class Example extends React.Component {
+      counter = 0;
+
+      constructor(props) {
+        super(props);
+        this.state = {
+          items: [],
+        };
+      }
+
+      onRemoveItem = () => {
+        const { items } = this.state;
+        this.setState({
+          items: items.slice(0, items.length - 1),
+        });
+      };
+
+      onAddItem = () => {
+        this.setState({
+          items: this.state.items.concat(['item' + ++this.counter]),
+        });
+      };
+
+      handleAddItems = calls => {
+        let items = [];
+        for (let i = 0; i < calls; i++) {
+          items.push('item' + ++this.counter);
+        }
+        this.setState(prevState => ({
+          items,
+        }));
+        setTimeout(() => {
+          this.setState(prevState => ({
+            items: prevState.items.slice(
+              0,
+              Math.floor((prevState.items.length - 1) / 2),
+            ),
+          }));
+        }, 50);
+      };
+
+      onAddItems = () => {
+        setTimeout(this.handleAddItems(50), 0);
+        setTimeout(this.handleAddItems(50), 20);
+      };
+
+      render() {
+        const { items } = this.state;
+
+        return (
+          <div>
+            <section>
+              <button onClick={this.onRemoveItem}>Remove item</button>
+              <button onClick={this.onAddItem}>Add item</button>
+              <button onClick={() => this.onAddItems()}>Add many items</button>
+            </section>
+            <FlipMove
+              typeName={'ul'}
+              duration="200"
+              enterAnimation={{
+                from: {
+                  transform: 'translateX(-10%)',
+                  opacity: 0.1,
+                },
+                to: {
+                  transform: 'translateX(0)',
+                  opacity: 1,
+                },
+              }}
+              leaveAnimation={{
+                from: {
+                  transform: 'translateX(0)',
+                  opacity: 1,
+                },
+                to: {
+                  transform: 'translateX(-10%)',
+                  opacity: 0.0,
+                },
+              }}
+            >
+              {items.map(item =>
+                <li key={item} id={item}>
+                  {item}
+                </li>,
+              )}
+            </FlipMove>
+          </div>
+        );
+      }
+    }
+
+    return (
+      <div>
+        <legend>
+          Spam "add many items" button, then inspect first element. it will be
+          overlayed by a zombie element that wasnt correctle removed from the
+          DOM
+        </legend>
+        <Example />
+      </div>
+    );
+  })
+  .add('#141', () => {
     let count = 0;
     return (
       <FlipMoveWrapper
-        items={range(100).map(i => {return {id: `${i}`, text: `Header ${i}`}})}
+        items={range(100).map(i => {
+          return { id: `${i}`, text: `Header ${i}` };
+        })}
         flipMoveContainerStyles={{
           position: 'relative',
           height: '500px',
-          overflow: 'scroll'
+          overflow: 'scroll',
         }}
         listItemStyles={{
           position: 'sticky',
           top: 0,
           height: 20,
           backgroundColor: 'black',
-          color: 'white'
+          color: 'white',
         }}
       />
-    )
+    );
   });
-
 
 class Controls extends Component {
   constructor() {
     super();
-    this.state = { items: items.slice() }
+    this.state = { items: items.slice() };
   }
 
   buttonClickHandler() {
@@ -55,12 +157,12 @@ class Controls extends Component {
 
   listItemClickHandler(clickedItem) {
     this.setState({
-      items: this.state.items.filter( item => item !== clickedItem )
+      items: this.state.items.filter(item => item !== clickedItem),
     });
   }
 
   restore() {
-    this.setState({ items })
+    this.setState({ items });
   }
 
   renderItems() {
@@ -69,37 +171,41 @@ class Controls extends Component {
       borderRadius: '20px',
       padding: '1em 2em',
       marginBottom: '1em',
-      minWidth: 400
-    }
+      minWidth: 400,
+    };
 
     const answerStyle = {
-      fontSize: '16px'
-    }
-    return this.state.items.map( item => (
+      fontSize: '16px',
+    };
+    return this.state.items.map(item =>
       <div
         style={answerWrapperStyle}
         key={item.name}
         onClick={() => this.listItemClickHandler(item)}
       >
-        <div style={answerStyle}>{item.name}</div>
-      </div>
-    ))
+        <div style={answerStyle}>
+          {item.name}
+        </div>
+      </div>,
+    );
   }
 
   render() {
     return (
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        minHeight: '600px',
-        background: '#DDD'
-      }}>
-        <div style={{marginBottom: '50px'}}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          minHeight: '600px',
+          background: '#DDD',
+        }}
+      >
+        <div style={{ marginBottom: '50px' }}>
           <button onClick={::this.buttonClickHandler}>Remove</button>
           <button onClick={::this.restore}>add</button>
         </div>
         <FlipMove enterAnimation="elevator" leaveAnimation="elevator">
-          { this.renderItems() }
+          {this.renderItems()}
         </FlipMove>
       </div>
     );

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
-import { storiesOf, action } from '@kadira/storybook';
-import shuffle from 'lodash/shuffle';
-import sampleSize from 'lodash/sampleSize';
+import { storiesOf } from '@kadira/storybook';
 import range from 'lodash/range';
 
 import FlipMoveWrapper from './helpers/FlipMoveWrapper';


### PR DESCRIPTION
this adresses https://github.com/joshwcomeau/react-flip-move/issues/120#issuecomment-301613739

i've added a story that reproduces the issue based off of @ConneXN good work. my workaround sets the z-index for elements starting their leaving-transition to -1, so they dont catch click events meant for the (visible) element below them.

this is *not* a solve, seeing as we still have zombie nodes, but it satisfies my current requirments. maybe it helps someone else find a real solution.