### PR TITLE
Fix Issue120

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -420,7 +420,6 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       if (ev.target !== domNode) return;
 
       if (getKey(child) === '.$item151')
-        console.log('triggering tranitionEnd listener for 151');
       // Remove the 'transition' inline style we added. This is cleanup.
       domNode.style.transition = '';
 
@@ -430,7 +429,6 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       domNode.removeEventListener(transitionEnd, transitionEndHandler);
 
       if (child.leaving) {
-        if (getKey(child) === '.$item151') console.log('removing child 151');
         this.removeChildData(getKey(child));
       }
     };
@@ -620,14 +618,13 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
   }
 
   removeChildData(key: string): void {
-    if (key === '.$item151') console.log("removing item151 from this.childrenData")
     delete this.childrenData[key];
-    /*this.setState(prevState => {
+    this.setState(prevState => {
       return {
         ...prevState,
         children: prevState.children.filter(child => child.key !== key),
       };
-    });*/
+    });
   }
 
   createHeightPlaceholder(): Element<*> {
@@ -685,8 +682,6 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
     const children = this.childrenWithRefs();
 
-    const Item151StillInChildren = children.find(child => child.key === '.$item151');
-    console.log(Item151StillInChildren ? "rerendering with 151 in children" : "rendering without 151")
     if (leaveAnimation && maintainContainerHeight) {
       children.push(this.createHeightPlaceholder());
     }

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -237,7 +237,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     //
 
     // Start by marking new children as 'entering'
-    const updatedChildren: Array<ChildData> = nextChildren.map(nextChild => {
+    const updatedChildren: Array<ChildData> = nextChildren.map((nextChild) => {
       const child = this.findChildByKey(nextChild.key || '');
 
       // If the current child did exist, but it was in the midst of leaving,
@@ -295,7 +295,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
         child => child.leaving,
       );
 
-      leavingChildren.forEach(leavingChild => {
+      leavingChildren.forEach((leavingChild) => {
         const childData = this.getChildData(getKey(leavingChild));
 
         // We need to take the items out of the "flow" of the document, so that
@@ -317,7 +317,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     // For all children not in the middle of entering or leaving,
     // we need to reset the transition, so that the NEW shuffle starts from
     // the right place.
-    this.state.children.forEach(child => {
+    this.state.children.forEach((child) => {
       const { domNode } = this.getChildData(getKey(child));
 
       // Ignore children that don't render DOM nodes (eg. by returning null)
@@ -419,7 +419,6 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       // but on a nested transition (eg. a hover effect). Ignore these cases.
       if (ev.target !== domNode) return;
 
-      if (getKey(child) === '.$item151')
       // Remove the 'transition' inline style we added. This is cleanup.
       domNode.style.transition = '';
 
@@ -474,7 +473,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     const elements: Array<ElementShape> = [];
     const domNodes: Array<?HTMLElement> = [];
 
-    this.childrenToAnimate.forEach(childKey => {
+    this.childrenToAnimate.forEach((childKey) => {
       // If this was an exit animation, the child may no longer exist.
       // If so, skip it.
       const child = this.findChildByKey(childKey);
@@ -506,7 +505,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
     this.parentData.boundingBox = this.props.getPosition(parentDomNode);
 
-    this.state.children.forEach(child => {
+    this.state.children.forEach((child) => {
       const childKey = getKey(child);
 
       // It is possible that a child does not have a `key` property;
@@ -619,12 +618,10 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
   removeChildData(key: string): void {
     delete this.childrenData[key];
-    this.setState(prevState => {
-      return {
-        ...prevState,
-        children: prevState.children.filter(child => child.key !== key),
-      };
-    });
+    this.setState(prevState => ({
+      ...prevState,
+      children: prevState.children.filter(child => child.key !== key),
+    }));
   }
 
   createHeightPlaceholder(): Element<*> {

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -6,13 +6,9 @@
  * For information on how this code is laid out, check out CODE_TOUR.md
  */
 
- /* eslint-disable react/prop-types */
+/* eslint-disable react/prop-types */
 
-import React, {
-  Component,
-  Element,
-  Children,
-} from 'react';
+import React, { Component, Element, Children } from 'react';
 
 import './polyfills';
 import propConverter from './prop-converter';
@@ -55,7 +51,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
   // can complete. Because we cannot mutate props, we make `state` the source
   // of truth.
   state = {
-    children: Children.toArray(this.props.children).map((element: Element<*>) => ({
+    children: Children.toArray(
+      this.props.children,
+    ).map((element: Element<*>) => ({
       ...element,
       element,
       appearing: true,
@@ -94,7 +92,6 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     domNode: null,
   };
 
-
   // Keep track of remaining animations so we know when to fire the
   // all-finished callback, and clean up after ourselves.
   // NOTE: we can't simply use childrenToAnimate.length to track remaining
@@ -106,10 +103,8 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
   componentDidMount() {
     // Run our `appearAnimation` if it was requested, right after the
     // component mounts.
-    const shouldTriggerFLIP = (
-      this.props.appearAnimation &&
-      !this.isAnimationDisabled(this.props)
-    );
+    const shouldTriggerFLIP =
+      this.props.appearAnimation && !this.isAnimationDisabled(this.props);
 
     if (shouldTriggerFLIP) {
       this.prepForAnimation();
@@ -125,7 +120,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     this.updateBoundingBoxCaches();
 
     // Convert opaque children object to array.
-    const nextChildren: Array<Element<*>> = Children.toArray(nextProps.children);
+    const nextChildren: Array<Element<*>> = Children.toArray(
+      nextProps.children,
+    );
 
     // Next, we need to update our state, so that it contains our new set of
     // children. If animation is disabled or unsupported, this is easy;
@@ -148,14 +145,16 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     // At the end of the transition, we clean up nodes that need to be removed.
     // We DON'T want this cleanup to trigger another update.
 
-    const oldChildrenKeys: Array<string> = Children.toArray(this.props.children).map(d => d.key);
-    const nextChildrenKeys: Array<string> =
-        Children.toArray(previousProps.children).map(d => d.key);
+    const oldChildrenKeys: Array<string> = Children.toArray(
+      this.props.children,
+    ).map(d => d.key);
+    const nextChildrenKeys: Array<string> = Children.toArray(
+      previousProps.children,
+    ).map(d => d.key);
 
-    const shouldTriggerFLIP = (
+    const shouldTriggerFLIP =
       !arraysEqual(oldChildrenKeys, nextChildrenKeys) &&
-      !this.isAnimationDisabled(this.props)
-    );
+      !this.isAnimationDisabled(this.props);
 
     if (shouldTriggerFLIP) {
       this.prepForAnimation();
@@ -165,7 +164,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
   runAnimation = () => {
     const dynamicChildren = this.state.children.filter(
-      this.doesChildNeedToBeAnimated
+      this.doesChildNeedToBeAnimated,
     );
 
     dynamicChildren.forEach((child, n) => {
@@ -195,7 +194,12 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       return false;
     }
 
-    const { appearAnimation, enterAnimation, leaveAnimation, getPosition } = this.props;
+    const {
+      appearAnimation,
+      enterAnimation,
+      leaveAnimation,
+      getPosition,
+    } = this.props;
 
     const isAppearingWithAnimation = child.appearing && appearAnimation;
     const isEnteringWithAnimation = child.entering && enterAnimation;
@@ -221,7 +225,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     return dX !== 0 || dY !== 0;
   };
 
-  calculateNextSetOfChildren(nextChildren: Array<Element<*>>): Array<ChildData> {
+  calculateNextSetOfChildren(
+    nextChildren: Array<Element<*>>,
+  ): Array<ChildData> {
     // We want to:
     //   - Mark all new children as `entering`
     //   - Pull in previous children that aren't in nextChildren, and mark them
@@ -231,7 +237,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     //
 
     // Start by marking new children as 'entering'
-    const updatedChildren: Array<ChildData> = nextChildren.map((nextChild) => {
+    const updatedChildren: Array<ChildData> = nextChildren.map(nextChild => {
       const child = this.findChildByKey(nextChild.key || '');
 
       // If the current child did exist, but it was in the midst of leaving,
@@ -280,20 +286,16 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     // - update the placeholder container height, if needed, to ensure that
     //   the parent's height doesn't collapse.
 
-    const {
-      leaveAnimation,
-      maintainContainerHeight,
-      getPosition,
-    } = this.props;
+    const { leaveAnimation, maintainContainerHeight, getPosition } = this.props;
 
     // we need to make all leaving nodes "invisible" to the layout calculations
     // that will take place in the next step (this.runAnimation).
     if (leaveAnimation) {
-      const leavingChildren = this.state.children.filter(child => (
-        child.leaving
-      ));
+      const leavingChildren = this.state.children.filter(
+        child => child.leaving,
+      );
 
-      leavingChildren.forEach((leavingChild) => {
+      leavingChildren.forEach(leavingChild => {
         const childData = this.getChildData(getKey(leavingChild));
 
         // We need to take the items out of the "flow" of the document, so that
@@ -315,7 +317,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     // For all children not in the middle of entering or leaving,
     // we need to reset the transition, so that the NEW shuffle starts from
     // the right place.
-    this.state.children.forEach((child) => {
+    this.state.children.forEach(child => {
       const { domNode } = this.getChildData(getKey(child));
 
       // Ignore children that don't render DOM nodes (eg. by returning null)
@@ -417,6 +419,8 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       // but on a nested transition (eg. a hover effect). Ignore these cases.
       if (ev.target !== domNode) return;
 
+      if (getKey(child) === '.$item151')
+        console.log('triggering tranitionEnd listener for 151');
       // Remove the 'transition' inline style we added. This is cleanup.
       domNode.style.transition = '';
 
@@ -426,6 +430,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       domNode.removeEventListener(transitionEnd, transitionEndHandler);
 
       if (child.leaving) {
+        if (getKey(child) === '.$item151') console.log('removing child 151');
         this.removeChildData(getKey(child));
       }
     };
@@ -471,7 +476,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     const elements: Array<ElementShape> = [];
     const domNodes: Array<?HTMLElement> = [];
 
-    this.childrenToAnimate.forEach((childKey) => {
+    this.childrenToAnimate.forEach(childKey => {
       // If this was an exit animation, the child may no longer exist.
       // If so, skip it.
       const child = this.findChildByKey(childKey);
@@ -501,11 +506,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       return;
     }
 
-    this.parentData.boundingBox = this.props.getPosition(
-      parentDomNode
-    );
+    this.parentData.boundingBox = this.props.getPosition(parentDomNode);
 
-    this.state.children.forEach((child) => {
+    this.state.children.forEach(child => {
       const childKey = getKey(child);
 
       // It is possible that a child does not have a `key` property;
@@ -541,9 +544,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
   computeInitialStyles(child: ChildData): Styles {
     if (child.appearing) {
-      return this.props.appearAnimation
-        ? this.props.appearAnimation.from
-        : {};
+      return this.props.appearAnimation ? this.props.appearAnimation.from : {};
     } else if (child.entering) {
       if (!this.props.enterAnimation) {
         return {};
@@ -559,9 +560,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
         ...this.props.enterAnimation.from,
       };
     } else if (child.leaving) {
-      return this.props.leaveAnimation
-        ? this.props.leaveAnimation.from
-        : {};
+      return this.props.leaveAnimation ? this.props.leaveAnimation.from : {};
     }
 
     const childData = this.getChildData(getKey(child));
@@ -595,12 +594,10 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     return (
       noBrowserSupport ||
       props.disableAllAnimations ||
-      (
-        props.duration === 0 &&
+      (props.duration === 0 &&
         props.delay === 0 &&
         props.staggerDurationBy === 0 &&
-        props.staggerDelayBy === 0
-      )
+        props.staggerDelayBy === 0)
     );
   }
 
@@ -623,7 +620,14 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
   }
 
   removeChildData(key: string): void {
+    if (key === '.$item151') console.log("removing item151 from this.childrenData")
     delete this.childrenData[key];
+    /*this.setState(prevState => {
+      return {
+        ...prevState,
+        children: prevState.children.filter(child => child.key !== key),
+      };
+    });*/
   }
 
   createHeightPlaceholder(): Element<*> {
@@ -635,21 +639,20 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     const isContainerAList = typeName === 'ul' || typeName === 'ol';
     const placeholderType = isContainerAList ? 'li' : 'div';
 
-    return React.createElement(
-      placeholderType,
-      {
-        key: 'height-placeholder',
-        ref: (domNode: ?HTMLElement) => { this.heightPlaceholderData.domNode = domNode; },
-        style: { visibility: 'hidden', height: 0 },
-      }
-    );
+    return React.createElement(placeholderType, {
+      key: 'height-placeholder',
+      ref: (domNode: ?HTMLElement) => {
+        this.heightPlaceholderData.domNode = domNode;
+      },
+      style: { visibility: 'hidden', height: 0 },
+    });
   }
 
   childrenWithRefs(): Array<Element<*>> {
     // We need to clone the provided children, capturing a reference to the
     // underlying DOM node. Flip Move needs to use the React escape hatches to
     // be able to do its calculations.
-    return this.state.children.map(child => (
+    return this.state.children.map(child =>
       React.cloneElement(child.element, {
         ref: (element: HTMLElement | Component<*, *, *>) => {
           // Stateless Functional Components are not supported by FlipMove,
@@ -661,8 +664,8 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
           const domNode: ?HTMLElement = getNativeNode(element);
           this.setChildData(getKey(child), { domNode });
         },
-      })
-    ));
+      }),
+    );
   }
 
   render() {
@@ -675,19 +678,20 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
     const props: DelegatedProps = {
       ...delegated,
-      ref: (node: ?HTMLElement) => { this.parentData.domNode = node; },
+      ref: (node: ?HTMLElement) => {
+        this.parentData.domNode = node;
+      },
     };
 
     const children = this.childrenWithRefs();
+
+    const Item151StillInChildren = children.find(child => child.key === '.$item151');
+    console.log(Item151StillInChildren ? "rerendering with 151 in children" : "rendering without 151")
     if (leaveAnimation && maintainContainerHeight) {
       children.push(this.createHeightPlaceholder());
     }
 
-    return React.createElement(
-      typeName,
-      props,
-      children
-    );
+    return React.createElement(typeName, props, children);
   }
 }
 

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -6,7 +6,7 @@
  * For information on how this code is laid out, check out CODE_TOUR.md
  */
 
-/* eslint-disable react/prop-types */
+ /* eslint-disable react/prop-types */
 
 import React, {
   Component,
@@ -150,7 +150,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
     const oldChildrenKeys: Array<string> = Children.toArray(this.props.children).map(d => d.key);
     const nextChildrenKeys: Array<string> =
-      Children.toArray(previousProps.children).map(d => d.key);
+        Children.toArray(previousProps.children).map(d => d.key);
 
     const shouldTriggerFLIP = (
       !arraysEqual(oldChildrenKeys, nextChildrenKeys) &&
@@ -443,12 +443,12 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     if (this.remainingAnimations === 0) {
       // Remove any items from the DOM that have left, and reset `entering`.
       const nextChildren: Array<ChildData> = this.state.children
-      .filter(({ leaving }) => !leaving)
-      .map(item => ({
-        ...item,
-        appearing: false,
-        entering: false,
-      }));
+        .filter(({ leaving }) => !leaving)
+        .map(item => ({
+          ...item,
+          appearing: false,
+          entering: false,
+        }));
 
       this.setState({ children: nextChildren }, () => {
         if (typeof this.props.onFinishAll === 'function') {

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -8,7 +8,11 @@
 
 /* eslint-disable react/prop-types */
 
-import React, { Component, Element, Children } from 'react';
+import React, {
+  Component,
+  Element,
+  Children,
+} from 'react';
 
 import './polyfills';
 import propConverter from './prop-converter';
@@ -51,9 +55,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
   // can complete. Because we cannot mutate props, we make `state` the source
   // of truth.
   state = {
-    children: Children.toArray(
-      this.props.children,
-    ).map((element: Element<*>) => ({
+    children: Children.toArray(this.props.children).map((element: Element<*>) => ({
       ...element,
       element,
       appearing: true,
@@ -92,6 +94,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     domNode: null,
   };
 
+
   // Keep track of remaining animations so we know when to fire the
   // all-finished callback, and clean up after ourselves.
   // NOTE: we can't simply use childrenToAnimate.length to track remaining
@@ -103,8 +106,10 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
   componentDidMount() {
     // Run our `appearAnimation` if it was requested, right after the
     // component mounts.
-    const shouldTriggerFLIP =
-      this.props.appearAnimation && !this.isAnimationDisabled(this.props);
+    const shouldTriggerFLIP = (
+      this.props.appearAnimation &&
+      !this.isAnimationDisabled(this.props)
+    );
 
     if (shouldTriggerFLIP) {
       this.prepForAnimation();
@@ -120,9 +125,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     this.updateBoundingBoxCaches();
 
     // Convert opaque children object to array.
-    const nextChildren: Array<Element<*>> = Children.toArray(
-      nextProps.children,
-    );
+    const nextChildren: Array<Element<*>> = Children.toArray(nextProps.children);
 
     // Next, we need to update our state, so that it contains our new set of
     // children. If animation is disabled or unsupported, this is easy;
@@ -145,16 +148,14 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     // At the end of the transition, we clean up nodes that need to be removed.
     // We DON'T want this cleanup to trigger another update.
 
-    const oldChildrenKeys: Array<string> = Children.toArray(
-      this.props.children,
-    ).map(d => d.key);
-    const nextChildrenKeys: Array<string> = Children.toArray(
-      previousProps.children,
-    ).map(d => d.key);
+    const oldChildrenKeys: Array<string> = Children.toArray(this.props.children).map(d => d.key);
+    const nextChildrenKeys: Array<string> =
+      Children.toArray(previousProps.children).map(d => d.key);
 
-    const shouldTriggerFLIP =
+    const shouldTriggerFLIP = (
       !arraysEqual(oldChildrenKeys, nextChildrenKeys) &&
-      !this.isAnimationDisabled(this.props);
+      !this.isAnimationDisabled(this.props)
+    );
 
     if (shouldTriggerFLIP) {
       this.prepForAnimation();
@@ -164,7 +165,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
   runAnimation = () => {
     const dynamicChildren = this.state.children.filter(
-      this.doesChildNeedToBeAnimated,
+      this.doesChildNeedToBeAnimated
     );
 
     dynamicChildren.forEach((child, n) => {
@@ -194,12 +195,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       return false;
     }
 
-    const {
-      appearAnimation,
-      enterAnimation,
-      leaveAnimation,
-      getPosition,
-    } = this.props;
+    const { appearAnimation, enterAnimation, leaveAnimation, getPosition } = this.props;
 
     const isAppearingWithAnimation = child.appearing && appearAnimation;
     const isEnteringWithAnimation = child.entering && enterAnimation;
@@ -225,9 +221,7 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     return dX !== 0 || dY !== 0;
   };
 
-  calculateNextSetOfChildren(
-    nextChildren: Array<Element<*>>,
-  ): Array<ChildData> {
+  calculateNextSetOfChildren(nextChildren: Array<Element<*>>): Array<ChildData> {
     // We want to:
     //   - Mark all new children as `entering`
     //   - Pull in previous children that aren't in nextChildren, and mark them
@@ -286,14 +280,18 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     // - update the placeholder container height, if needed, to ensure that
     //   the parent's height doesn't collapse.
 
-    const { leaveAnimation, maintainContainerHeight, getPosition } = this.props;
+    const {
+      leaveAnimation,
+      maintainContainerHeight,
+      getPosition,
+    } = this.props;
 
     // we need to make all leaving nodes "invisible" to the layout calculations
     // that will take place in the next step (this.runAnimation).
     if (leaveAnimation) {
-      const leavingChildren = this.state.children.filter(
-        child => child.leaving,
-      );
+      const leavingChildren = this.state.children.filter(child => (
+        child.leaving
+      ));
 
       leavingChildren.forEach((leavingChild) => {
         const childData = this.getChildData(getKey(leavingChild));
@@ -445,12 +443,12 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     if (this.remainingAnimations === 0) {
       // Remove any items from the DOM that have left, and reset `entering`.
       const nextChildren: Array<ChildData> = this.state.children
-        .filter(({ leaving }) => !leaving)
-        .map(item => ({
-          ...item,
-          appearing: false,
-          entering: false,
-        }));
+      .filter(({ leaving }) => !leaving)
+      .map(item => ({
+        ...item,
+        appearing: false,
+        entering: false,
+      }));
 
       this.setState({ children: nextChildren }, () => {
         if (typeof this.props.onFinishAll === 'function') {
@@ -503,7 +501,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
       return;
     }
 
-    this.parentData.boundingBox = this.props.getPosition(parentDomNode);
+    this.parentData.boundingBox = this.props.getPosition(
+      parentDomNode
+    );
 
     this.state.children.forEach((child) => {
       const childKey = getKey(child);
@@ -541,7 +541,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
   computeInitialStyles(child: ChildData): Styles {
     if (child.appearing) {
-      return this.props.appearAnimation ? this.props.appearAnimation.from : {};
+      return this.props.appearAnimation
+        ? this.props.appearAnimation.from
+        : {};
     } else if (child.entering) {
       if (!this.props.enterAnimation) {
         return {};
@@ -557,7 +559,9 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
         ...this.props.enterAnimation.from,
       };
     } else if (child.leaving) {
-      return this.props.leaveAnimation ? this.props.leaveAnimation.from : {};
+      return this.props.leaveAnimation
+        ? this.props.leaveAnimation.from
+        : {};
     }
 
     const childData = this.getChildData(getKey(child));
@@ -591,10 +595,12 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     return (
       noBrowserSupport ||
       props.disableAllAnimations ||
-      (props.duration === 0 &&
+      (
+        props.duration === 0 &&
         props.delay === 0 &&
         props.staggerDurationBy === 0 &&
-        props.staggerDelayBy === 0)
+        props.staggerDelayBy === 0
+      )
     );
   }
 
@@ -633,20 +639,21 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
     const isContainerAList = typeName === 'ul' || typeName === 'ol';
     const placeholderType = isContainerAList ? 'li' : 'div';
 
-    return React.createElement(placeholderType, {
-      key: 'height-placeholder',
-      ref: (domNode: ?HTMLElement) => {
-        this.heightPlaceholderData.domNode = domNode;
-      },
-      style: { visibility: 'hidden', height: 0 },
-    });
+    return React.createElement(
+      placeholderType,
+      {
+        key: 'height-placeholder',
+        ref: (domNode: ?HTMLElement) => { this.heightPlaceholderData.domNode = domNode; },
+        style: { visibility: 'hidden', height: 0 },
+      }
+    );
   }
 
   childrenWithRefs(): Array<Element<*>> {
     // We need to clone the provided children, capturing a reference to the
     // underlying DOM node. Flip Move needs to use the React escape hatches to
     // be able to do its calculations.
-    return this.state.children.map(child =>
+    return this.state.children.map(child => (
       React.cloneElement(child.element, {
         ref: (element: HTMLElement | Component<*, *, *>) => {
           // Stateless Functional Components are not supported by FlipMove,
@@ -658,8 +665,8 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
           const domNode: ?HTMLElement = getNativeNode(element);
           this.setChildData(getKey(child), { domNode });
         },
-      }),
-    );
+      })
+    ));
   }
 
   render() {
@@ -672,18 +679,19 @@ class FlipMove extends Component<void, ConvertedProps, FlipMoveState> {
 
     const props: DelegatedProps = {
       ...delegated,
-      ref: (node: ?HTMLElement) => {
-        this.parentData.domNode = node;
-      },
+      ref: (node: ?HTMLElement) => { this.parentData.domNode = node; },
     };
 
     const children = this.childrenWithRefs();
-
     if (leaveAnimation && maintainContainerHeight) {
       children.push(this.createHeightPlaceholder());
     }
 
-    return React.createElement(typeName, props, children);
+    return React.createElement(
+      typeName,
+      props,
+      children
+    );
   }
 }
 

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -169,7 +169,6 @@ export const removeNodeFromDOMFlow = (
 
   const styles: Styles = {
     position: 'absolute',
-    zIndex: '-1',
     top: `${topOffset - margins['margin-top']}px`,
     left: `${boundingBox.left - margins['margin-left']}px`,
     right: `${boundingBox.right - margins['margin-right']}px`,

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -169,6 +169,7 @@ export const removeNodeFromDOMFlow = (
 
   const styles: Styles = {
     position: 'absolute',
+    zIndex: -1,
     top: `${topOffset - margins['margin-top']}px`,
     left: `${boundingBox.left - margins['margin-left']}px`,
     right: `${boundingBox.right - margins['margin-right']}px`,

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -169,7 +169,7 @@ export const removeNodeFromDOMFlow = (
 
   const styles: Styles = {
     position: 'absolute',
-    zIndex: -1,
+    zIndex: '-1',
     top: `${topOffset - margins['margin-top']}px`,
     left: `${boundingBox.left - margins['margin-left']}px`,
     right: `${boundingBox.right - margins['margin-right']}px`,

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -11,39 +11,141 @@ const items = [
   { name: 'Potent Potables' },
   { name: 'The Pen is Mightier' },
   { name: 'Famous Horsemen' },
-  { name: 'A Petit Déjeuner' }
-]
+  { name: 'A Petit Déjeuner' },
+];
 
 storiesOf('Github Issues', module)
-  .add('#31', () => (
-    <Controls duration={400} />
-  ))
-  .add('#141' , () => {
+  .add('#31', () => <Controls duration={400} />)
+  .add('#120', () => {
+    class Example extends React.Component {
+      counter = 0;
+
+      constructor(props) {
+        super(props);
+        this.state = {
+          items: [],
+        };
+      }
+
+      onRemoveItem = () => {
+        const { items } = this.state;
+        this.setState({
+          items: items.slice(0, items.length - 1),
+        });
+      };
+
+      onAddItem = () => {
+        this.setState({
+          items: this.state.items.concat(['item' + ++this.counter]),
+        });
+      };
+
+      handleAddItems = calls => {
+        let items = [];
+        for (let i = 0; i < calls; i++) {
+          items.push('item' + ++this.counter);
+        }
+        this.setState(prevState => ({
+          items,
+        }));
+        setTimeout(() => {
+          this.setState(prevState => ({
+            items: prevState.items.slice(
+              0,
+              Math.floor((prevState.items.length - 1) / 2),
+            ),
+          }));
+        }, 50);
+      };
+
+      onAddItems = () => {
+        setTimeout(this.handleAddItems(50), 0);
+        setTimeout(this.handleAddItems(50), 20);
+      };
+
+      render() {
+        const { items } = this.state;
+
+        return (
+          <div>
+            <section>
+              <button onClick={this.onRemoveItem}>Remove item</button>
+              <button onClick={this.onAddItem}>Add item</button>
+              <button onClick={() => this.onAddItems()}>Add many items</button>
+            </section>
+            <FlipMove
+              typeName={'ul'}
+              duration="200"
+              enterAnimation={{
+                from: {
+                  transform: 'translateX(-10%)',
+                  opacity: 0.1,
+                },
+                to: {
+                  transform: 'translateX(0)',
+                  opacity: 1,
+                },
+              }}
+              leaveAnimation={{
+                from: {
+                  transform: 'translateX(0)',
+                  opacity: 1,
+                },
+                to: {
+                  transform: 'translateX(-10%)',
+                  opacity: 0.0,
+                },
+              }}
+            >
+              {items.map(item =>
+                <li key={item} id={item}>
+                  {item}
+                </li>,
+              )}
+            </FlipMove>
+          </div>
+        );
+      }
+    }
+
+    return (
+      <div>
+        <legend>
+          Spam "add many items" button, then inspect first element. it will be
+          overlayed by a zombie element that wasnt correctle removed from the
+          DOM
+        </legend>
+        <Example />
+      </div>
+    );
+  })
+  .add('#141', () => {
     let count = 0;
     return (
       <FlipMoveWrapper
-        items={range(100).map(i => {return {id: `${i}`, text: `Header ${i}`}})}
+        items={range(100).map(i => {
+          return { id: `${i}`, text: `Header ${i}` };
+        })}
         flipMoveContainerStyles={{
           position: 'relative',
           height: '500px',
-          overflow: 'scroll'
+          overflow: 'scroll',
         }}
         listItemStyles={{
           position: 'sticky',
           top: 0,
           height: 20,
           backgroundColor: 'black',
-          color: 'white'
+          color: 'white',
         }}
       />
-    )
+    );
   });
-
 
 class Controls extends Component {
   constructor() {
     super();
-    this.state = { items: items.slice() }
+    this.state = { items: items.slice() };
   }
 
   buttonClickHandler() {
@@ -55,12 +157,12 @@ class Controls extends Component {
 
   listItemClickHandler(clickedItem) {
     this.setState({
-      items: this.state.items.filter( item => item !== clickedItem )
+      items: this.state.items.filter(item => item !== clickedItem),
     });
   }
 
   restore() {
-    this.setState({ items })
+    this.setState({ items });
   }
 
   renderItems() {
@@ -69,37 +171,41 @@ class Controls extends Component {
       borderRadius: '20px',
       padding: '1em 2em',
       marginBottom: '1em',
-      minWidth: 400
-    }
+      minWidth: 400,
+    };
 
     const answerStyle = {
-      fontSize: '16px'
-    }
-    return this.state.items.map( item => (
+      fontSize: '16px',
+    };
+    return this.state.items.map(item =>
       <div
         style={answerWrapperStyle}
         key={item.name}
         onClick={() => this.listItemClickHandler(item)}
       >
-        <div style={answerStyle}>{item.name}</div>
-      </div>
-    ))
+        <div style={answerStyle}>
+          {item.name}
+        </div>
+      </div>,
+    );
   }
 
   render() {
     return (
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        minHeight: '600px',
-        background: '#DDD'
-      }}>
-        <div style={{marginBottom: '50px'}}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          minHeight: '600px',
+          background: '#DDD',
+        }}
+      >
+        <div style={{ marginBottom: '50px' }}>
           <button onClick={::this.buttonClickHandler}>Remove</button>
           <button onClick={::this.restore}>add</button>
         </div>
         <FlipMove enterAnimation="elevator" leaveAnimation="elevator">
-          { this.renderItems() }
+          {this.renderItems()}
         </FlipMove>
       </div>
     );

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -9,11 +9,13 @@ const items = [
   { name: 'Potent Potables' },
   { name: 'The Pen is Mightier' },
   { name: 'Famous Horsemen' },
-  { name: 'A Petit Déjeuner' },
-];
+  { name: 'A Petit Déjeuner' }
+]
 
 storiesOf('Github Issues', module)
-  .add('#31', () => <Controls duration={400} />)
+  .add('#31', () => (
+    <Controls duration={400} />
+  ))
   .add('#120', () => {
     class Example extends React.Component {
       counter = 0;
@@ -113,29 +115,27 @@ storiesOf('Github Issues', module)
     let count = 0;
     return (
       <FlipMoveWrapper
-        items={range(100).map(i => {
-          return { id: `${i}`, text: `Header ${i}` };
-        })}
+        items={range(100).map(i => {return {id: `${i}`, text: `Header ${i}`}})}
         flipMoveContainerStyles={{
           position: 'relative',
           height: '500px',
-          overflow: 'scroll',
+          overflow: 'scroll'
         }}
         listItemStyles={{
           position: 'sticky',
           top: 0,
           height: 20,
           backgroundColor: 'black',
-          color: 'white',
+          color: 'white'
         }}
       />
     );
-  });
+  })
 
 class Controls extends Component {
   constructor() {
     super();
-    this.state = { items: items.slice() };
+    this.state = { items: items.slice() }
   }
 
   buttonClickHandler() {
@@ -147,12 +147,12 @@ class Controls extends Component {
 
   listItemClickHandler(clickedItem) {
     this.setState({
-      items: this.state.items.filter(item => item !== clickedItem),
+      items: this.state.items.filter( item => item !== clickedItem )
     });
   }
 
   restore() {
-    this.setState({ items });
+    this.setState({ items })
   }
 
   renderItems() {
@@ -161,41 +161,37 @@ class Controls extends Component {
       borderRadius: '20px',
       padding: '1em 2em',
       marginBottom: '1em',
-      minWidth: 400,
-    };
+      minWidth: 400
+    }
 
     const answerStyle = {
-      fontSize: '16px',
-    };
+      fontSize: '16px'
+    }
     return this.state.items.map(item =>
       <div
         style={answerWrapperStyle}
         key={item.name}
         onClick={() => this.listItemClickHandler(item)}
       >
-        <div style={answerStyle}>
-          {item.name}
-        </div>
+        <div style={answerStyle}>{item.name}</div>
       </div>,
     );
   }
 
   render() {
     return (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          minHeight: '600px',
-          background: '#DDD',
-        }}
-      >
-        <div style={{ marginBottom: '50px' }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: '600px',
+        background: '#DDD',
+      }}>
+        <div style={{marginBottom: '50px'}}>
           <button onClick={::this.buttonClickHandler}>Remove</button>
           <button onClick={::this.restore}>add</button>
         </div>
         <FlipMove enterAnimation="elevator" leaveAnimation="elevator">
-          {this.renderItems()}
+          { this.renderItems() }
         </FlipMove>
       </div>
     );

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
-import { storiesOf } from '@kadira/storybook';
+import { storiesOf, action } from '@kadira/storybook';
+import shuffle from 'lodash/shuffle';
+import sampleSize from 'lodash/sampleSize';
 import range from 'lodash/range';
 
 import FlipMoveWrapper from './helpers/FlipMoveWrapper';

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -129,8 +129,9 @@ storiesOf('Github Issues', module)
           color: 'white'
         }}
       />
-    );
-  })
+    )
+  });
+
 
 class Controls extends Component {
   constructor() {
@@ -167,15 +168,15 @@ class Controls extends Component {
     const answerStyle = {
       fontSize: '16px'
     }
-    return this.state.items.map(item =>
+    return this.state.items.map( item => (
       <div
         style={answerWrapperStyle}
         key={item.name}
         onClick={() => this.listItemClickHandler(item)}
       >
         <div style={answerStyle}>{item.name}</div>
-      </div>,
-    );
+      </div>
+    ))
   }
 
   render() {
@@ -184,7 +185,7 @@ class Controls extends Component {
         display: 'flex',
         alignItems: 'center',
         minHeight: '600px',
-        background: '#DDD',
+        background: '#DDD'
       }}>
         <div style={{marginBottom: '50px'}}>
           <button onClick={::this.buttonClickHandler}>Remove</button>

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -46,14 +46,6 @@ storiesOf('Github Issues', module)
         this.setState(prevState => ({
           items,
         }));
-        setTimeout(() => {
-          this.setState(prevState => ({
-            items: prevState.items.slice(
-              0,
-              Math.floor((prevState.items.length - 1) / 2),
-            ),
-          }));
-        }, 50);
       };
 
       onAddItems = () => {

--- a/stories/github-issues.stories.js
+++ b/stories/github-issues.stories.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
-import { storiesOf, action } from '@kadira/storybook';
-import shuffle from 'lodash/shuffle';
-import sampleSize from 'lodash/sampleSize';
+import { storiesOf } from '@kadira/storybook';
 import range from 'lodash/range';
 
 import FlipMoveWrapper from './helpers/FlipMoveWrapper';


### PR DESCRIPTION
Adressing https://github.com/joshwcomeau/react-flip-move/issues/120

So after spending some time tracking down the issue demonstrated in https://github.com/joshwcomeau/react-flip-move/pull/180/files#diff-5bc397e1b32daa8794012a8ea12ce91aR17 (based off of @ConneXNL work  ❤️ ), i found that upon deletion of the childData entry, state is not updated. this means no rerender is triggered, and when a rerender is eventually triggered, we still have a child without corresponding childData (i.e. a zombie).

i've console.logged the lifecycle of such an element in this commit: https://github.com/joshwcomeau/react-flip-move/pull/180/commits/7f6f5972a9141e9c29b2fd5bdbe137bcb2bcf49a

the fix implemented here updates state in the `removeChildData` call. this seems to be working fine, but i'd appreciate some feedback.