### PR TITLE
Fix weak types in libdef

### DIFF
--- a/flow-typed/react-flip-move_v2.9.x.js
+++ b/flow-typed/react-flip-move_v2.9.x.js
@@ -1,17 +1,15 @@
-import type { ComponentType, Element, Node } from 'react';
-
-declare module 'react-flip-move' {
+declare module "react-flip-move" {
   declare export type Styles = {
-    [key: string]: string,
+    [key: string]: string
   };
 
   declare type ReactStyles = {
-    [key: string]: string | number,
+    [key: string]: string | number
   };
 
   declare export type Animation = {
     from: Styles,
-    to: Styles,
+    to: Styles
   };
 
   declare export type Presets = {
@@ -19,7 +17,7 @@ declare module 'react-flip-move' {
     fade: Animation,
     accordionVertical: Animation,
     accordionHorizontal: Animation,
-    none: null,
+    none: null
   };
 
   declare export type AnimationProp = $Keys<Presets> | boolean | Animation;
@@ -30,56 +28,80 @@ declare module 'react-flip-move' {
     bottom: number,
     left: number,
     height: number,
-    width: number,
+    width: number
   };
 
   // can't use $Shape<React$Element<*>> here, because we use it in intersection
   declare export type ElementShape = {
-    type: $PropertyType<Element<*>, 'type'>,
-    props: $PropertyType<Element<*>, 'props'>,
-    key: $PropertyType<Element<*>, 'key'>,
-    ref: $PropertyType<Element<*>, 'ref'>,
+    +type: $PropertyType<React$Element<*>, "type">,
+    +props: $PropertyType<React$Element<*>, "props">,
+    +key: $PropertyType<React$Element<*>, "key">,
+    +ref: $PropertyType<React$Element<*>, "ref">
   };
 
   declare type ChildHook = (element: ElementShape, node: ?HTMLElement) => mixed;
 
   declare export type ChildrenHook = (
-    elements: Array<Element<*>>,
+    elements: Array<ElementShape>,
     nodes: Array<?HTMLElement>
   ) => mixed;
 
   declare export type GetPosition = (node: HTMLElement) => ClientRect;
 
-  declare export type VerticalAlignment = 'top' | 'bottom';
+  declare export type VerticalAlignment = "top" | "bottom";
 
-  declare export type CommonProps = {
-    children: Node,
+  // same as React.Node, but without fragments, see https://github.com/facebook/flow/issues/4781
+  declare export type Child = void | null | boolean | React$Element<*>;
+
+  // can't import from React, see https://github.com/facebook/flow/issues/4787
+  declare type ChildrenArray<T> = $ReadOnlyArray<ChildrenArray<T>> | T;
+
+  declare type BaseProps = {
     easing: string,
     typeName: string,
     disableAllAnimations: boolean,
     getPosition: GetPosition,
     maintainContainerHeight: boolean,
-    verticalAlignment: VerticalAlignment,
-    onStart?: ChildHook,
-    onFinish?: ChildHook,
-    onStartAll?: ChildrenHook,
-    onFinishAll?: ChildrenHook,
+    verticalAlignment: VerticalAlignment
   };
 
-  declare export type DelegatedProps = {
-    style?: ReactStyles,
-  };
-
-  declare export type FlipMoveProps = CommonProps & DelegatedProps & {
+  declare type PolymorphicProps = {
     duration: string | number,
     delay: string | number,
     staggerDurationBy: string | number,
     staggerDelayBy: string | number,
     enterAnimation: AnimationProp,
-    leaveAnimation: AnimationProp,
-    appearAnimation?: AnimationProp,
-    disableAnimations?: boolean, // deprecated, use disableAllAnimations instead
+    leaveAnimation: AnimationProp
   };
 
-  declare export default ComponentType<FlipMoveProps>;
+  declare type Hooks = {
+    onStart?: ChildHook,
+    onFinish?: ChildHook,
+    onStartAll?: ChildrenHook,
+    onFinishAll?: ChildrenHook
+  };
+
+  declare export type DelegatedProps = {
+    style?: ReactStyles
+  };
+
+  declare export type FlipMoveDefaultProps = BaseProps & PolymorphicProps;
+
+  declare export type CommonProps = BaseProps &
+    Hooks & {
+      children?: ChildrenArray<Child>
+    };
+
+  declare export type FlipMoveProps = FlipMoveDefaultProps &
+    CommonProps &
+    DelegatedProps & {
+      appearAnimation?: AnimationProp,
+      disableAnimations?: boolean // deprecated, use disableAllAnimations instead
+    };
+
+  declare class FlipMove extends React$Component<FlipMoveProps> {
+    static defaultProps: FlipMoveDefaultProps
+  }
+
+  declare export default typeof FlipMove
 }

--- a/flow-typed/react-flip-move_v2.9.x.js
+++ b/flow-typed/react-flip-move_v2.9.x.js
@@ -50,7 +50,6 @@ declare module "react-flip-move" {
 
   declare export type VerticalAlignment = "top" | "bottom";
 
-  // same as React.Node, but without fragments, see https://github.com/facebook/flow/issues/4781
   declare export type Child = void | null | boolean | React$Element<*>;
 
   // can't import from React, see https://github.com/facebook/flow/issues/4787

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -22,7 +22,7 @@ Please wrap your components in a native element (eg. <div>), or a non-functional
 export const primitiveNodeSupplied = warnOnce(`
 >> Error, via react-flip-move <<
 
-You provided a primitive (text, number, or boolean) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
+You provided a primitive (text or number) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
 
 Please wrap your value in a native element (eg. <span>), or a component.
 `);

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -90,7 +90,8 @@ function propConverter(
       // If the child doesn't have a key, it means we aren't animating it.
       // It's allowed to be an SFC, since we ignore it.
       Children.forEach(children, (child: Child) => {
-        if (child == null) {
+        // null, undefined, and booleans will be filtered out by Children.toArray
+        if (child == null || typeof child === 'boolean') {
           return;
         }
 

--- a/src/typings.js
+++ b/src/typings.js
@@ -1,6 +1,7 @@
 // @flow
 import type { Element } from 'react';
 import type {
+  Child,
   Styles,
   Animation,
   Presets,
@@ -16,6 +17,7 @@ import type {
 } from 'react-flip-move'; // eslint-disable-line import/extensions
 
 export type {
+  Child,
   Styles,
   Animation,
   Presets,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -340,7 +340,7 @@ Please wrap your components in a native element (eg. <div>), or a non-functional
         expect(warnStub).to.have.been.calledWith(`
 >> Error, via react-flip-move <<
 
-You provided a primitive (text, number, or boolean) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
+You provided a primitive (text or number) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
 
 Please wrap your value in a native element (eg. <span>), or a component.
 `);


### PR DESCRIPTION
This is a follow-up to #183 

It turned out that the way I used react types in libdef file leads to all of them coercing to `any` (see https://github.com/flowtype/flow-typed/issues/1209#issuecomment-326756417)

This PR fixes that, plus restricts children types to react elements, and items filtered out by `Children.toArray` (those include `undefined`, `null`, and booleans)

I also made a PR to `flow-typed` with new libdef, so that it's available for external usage: https://github.com/flowtype/flow-typed/pull/1210 
