### PR TITLE
do absolute check for node type

### DIFF
--- a/flow-typed/react-flip-move_v2.9.x.js
+++ b/flow-typed/react-flip-move_v2.9.x.js
@@ -1,15 +1,17 @@
-declare module "react-flip-move" {
+import type { ComponentType, Element, Node } from 'react';
+
+declare module 'react-flip-move' {
   declare export type Styles = {
-    [key: string]: string
+    [key: string]: string,
   };
 
   declare type ReactStyles = {
-    [key: string]: string | number
+    [key: string]: string | number,
   };
 
   declare export type Animation = {
     from: Styles,
-    to: Styles
+    to: Styles,
   };
 
   declare export type Presets = {
@@ -17,7 +19,7 @@ declare module "react-flip-move" {
     fade: Animation,
     accordionVertical: Animation,
     accordionHorizontal: Animation,
-    none: null
+    none: null,
   };
 
   declare export type AnimationProp = $Keys<Presets> | boolean | Animation;
@@ -28,79 +30,56 @@ declare module "react-flip-move" {
     bottom: number,
     left: number,
     height: number,
-    width: number
+    width: number,
   };
 
   // can't use $Shape<React$Element<*>> here, because we use it in intersection
   declare export type ElementShape = {
-    +type: $PropertyType<React$Element<*>, "type">,
-    +props: $PropertyType<React$Element<*>, "props">,
-    +key: $PropertyType<React$Element<*>, "key">,
-    +ref: $PropertyType<React$Element<*>, "ref">
+    type: $PropertyType<Element<*>, 'type'>,
+    props: $PropertyType<Element<*>, 'props'>,
+    key: $PropertyType<Element<*>, 'key'>,
+    ref: $PropertyType<Element<*>, 'ref'>,
   };
 
   declare type ChildHook = (element: ElementShape, node: ?HTMLElement) => mixed;
 
   declare export type ChildrenHook = (
-    elements: Array<ElementShape>,
+    elements: Array<Element<*>>,
     nodes: Array<?HTMLElement>
   ) => mixed;
 
   declare export type GetPosition = (node: HTMLElement) => ClientRect;
 
-  declare export type VerticalAlignment = "top" | "bottom";
+  declare export type VerticalAlignment = 'top' | 'bottom';
 
-  declare export type Child = void | null | boolean | React$Element<*>;
-
-  // can't import from React, see https://github.com/facebook/flow/issues/4787
-  declare type ChildrenArray<T> = $ReadOnlyArray<ChildrenArray<T>> | T;
-
-  declare type BaseProps = {
+  declare export type CommonProps = {
+    children: Node,
     easing: string,
     typeName: string,
     disableAllAnimations: boolean,
     getPosition: GetPosition,
     maintainContainerHeight: boolean,
-    verticalAlignment: VerticalAlignment
+    verticalAlignment: VerticalAlignment,
+    onStart?: ChildHook,
+    onFinish?: ChildHook,
+    onStartAll?: ChildrenHook,
+    onFinishAll?: ChildrenHook,
   };
 
-  declare type PolymorphicProps = {
+  declare export type DelegatedProps = {
+    style?: ReactStyles,
+  };
+
+  declare export type FlipMoveProps = CommonProps & DelegatedProps & {
     duration: string | number,
     delay: string | number,
     staggerDurationBy: string | number,
     staggerDelayBy: string | number,
     enterAnimation: AnimationProp,
-    leaveAnimation: AnimationProp
+    leaveAnimation: AnimationProp,
+    appearAnimation?: AnimationProp,
+    disableAnimations?: boolean, // deprecated, use disableAllAnimations instead
   };
 
-  declare type Hooks = {
-    onStart?: ChildHook,
-    onFinish?: ChildHook,
-    onStartAll?: ChildrenHook,
-    onFinishAll?: ChildrenHook
-  };
-
-  declare export type DelegatedProps = {
-    style?: ReactStyles
-  };
-
-  declare export type FlipMoveDefaultProps = BaseProps & PolymorphicProps;
-
-  declare export type CommonProps = BaseProps &
-    Hooks & {
-      children?: ChildrenArray<Child>
-    };
-
-  declare export type FlipMoveProps = FlipMoveDefaultProps &
-    CommonProps &
-    DelegatedProps & {
-      appearAnimation?: AnimationProp,
-      disableAnimations?: boolean // deprecated, use disableAllAnimations instead
-    };
-
-  declare class FlipMove extends React$Component<FlipMoveProps> {
-    static defaultProps: FlipMoveDefaultProps
-  }
-
-  declare export default typeof FlipMove
+  declare export default ComponentType<FlipMoveProps>;
 }

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -10,7 +10,7 @@
 
 import { Children, cloneElement, createElement, Component } from 'react';
 // eslint-disable-next-line no-duplicate-imports
-import type { Element, ElementRef, Key, ChildrenArray } from 'react';
+import type { Element, ElementRef, Key } from 'react';
 
 import './polyfills';
 import propConverter from './prop-converter';
@@ -26,7 +26,6 @@ import {
 } from './dom-manipulation';
 import { arraysEqual } from './helpers';
 import type {
-  Child,
   ConvertedProps,
   FlipMoveState,
   ElementShape,
@@ -44,12 +43,6 @@ function getKey(childData: ChildData): Key {
   return childData.key || '';
 }
 
-function getElementChildren(children: ChildrenArray<Child>): Array<Element<*>> {
-  // Fix incomplete typing of Children.toArray
-  // eslint-disable-next-line flowtype/no-weak-types
-  return (Children.toArray(children): any);
-}
-
 class FlipMove extends Component<ConvertedProps, FlipMoveState> {
   // Copy props.children into state.
   // To understand why this is important (and not an anti-pattern), consider
@@ -60,7 +53,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
   // can complete. Because we cannot mutate props, we make `state` the source
   // of truth.
   state = {
-    children: getElementChildren(
+    children: Children.toArray(
       this.props.children,
     ).map((element: Element<*>) => ({
       ...element,
@@ -129,7 +122,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     this.updateBoundingBoxCaches();
 
     // Convert opaque children object to array.
-    const nextChildren: Array<Element<*>> = getElementChildren(
+    const nextChildren: Array<Element<*>> = Children.toArray(
       nextProps.children,
     );
 
@@ -154,10 +147,10 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     // At the end of the transition, we clean up nodes that need to be removed.
     // We DON'T want this cleanup to trigger another update.
 
-    const oldChildrenKeys: Array<?Key> = getElementChildren(
+    const oldChildrenKeys: Array<?Key> = Children.toArray(
       this.props.children,
     ).map((d: Element<*>) => d.key);
-    const nextChildrenKeys: Array<?Key> = getElementChildren(
+    const nextChildrenKeys: Array<?Key> = Children.toArray(
       previousProps.children,
     ).map((d: Element<*>) => d.key);
 
@@ -247,7 +240,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
 
     // Start by marking new children as 'entering'
     const updatedChildren: Array<ChildData> = nextChildren.map(nextChild => {
-      const child = this.findChildByKey(nextChild.key);
+      const child = this.findChildByKey(nextChild.key || '');
 
       // If the current child did exist, but it was in the midst of leaving,
       // we want to treat it as though it's entering
@@ -457,8 +450,6 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
         .filter(({ leaving }) => !leaving)
         .map((item: ChildData) => ({
           ...item,
-          // fix for Flow
-          element: item.element,
           appearing: false,
           entering: false,
         }));
@@ -609,7 +600,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     );
   }
 
-  findChildByKey(key: ?Key): ?ChildData {
+  findChildByKey(key: Key): ?ChildData {
     return this.state.children.find(child => getKey(child) === key);
   }
 

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -7,13 +7,26 @@
  * They almost always have side effects, and will hopefully become the
  * only spot in the codebase with impure functions.
  */
-import { findDOMNode } from "react-dom";
-import type { ElementRef } from "react";
+import { findDOMNode } from 'react-dom';
+import type { ElementRef } from 'react';
 
-import { hyphenate } from "./helpers";
-import type { Styles, ClientRect, GetPosition, NodeData, VerticalAlignment, ConvertedProps } from "./typings";
+import { hyphenate } from './helpers';
+import type {
+  Styles,
+  ClientRect,
+  GetPosition,
+  NodeData,
+  VerticalAlignment,
+  ConvertedProps,
+} from './typings';
 
-export function applyStylesToDOMNode({ domNode, styles }: { domNode: HTMLElement, styles: Styles }) {
+export function applyStylesToDOMNode({
+  domNode,
+  styles,
+}: {
+  domNode: HTMLElement,
+  styles: Styles,
+}) {
   // Can't just do an object merge because domNode.styles is no regular object.
   // Need to do it this way for the engine to fire its `set` listeners.
   Object.keys(styles).forEach(key => {
@@ -24,33 +37,35 @@ export function applyStylesToDOMNode({ domNode, styles }: { domNode: HTMLElement
 // Modified from Modernizr
 export function whichTransitionEvent(): string {
   const transitions = {
-    transition: "transitionend",
-    "-o-transition": "oTransitionEnd",
-    "-moz-transition": "transitionend",
-    "-webkit-transition": "webkitTransitionEnd"
+    transition: 'transitionend',
+    '-o-transition': 'oTransitionEnd',
+    '-moz-transition': 'transitionend',
+    '-webkit-transition': 'webkitTransitionEnd',
   };
 
   // If we're running in a browserless environment (eg. SSR), it doesn't apply.
   // Return a placeholder string, for consistent type return.
-  if (typeof document === "undefined") return "";
+  if (typeof document === 'undefined') return '';
 
-  const el = document.createElement("fakeelement");
+  const el = document.createElement('fakeelement');
 
-  const match = Object.keys(transitions).find(t => el.style.getPropertyValue(t) !== undefined);
+  const match = Object.keys(transitions).find(
+    t => el.style.getPropertyValue(t) !== undefined,
+  );
 
   // If no `transition` is found, we must be running in a browser so ancient,
   // React itself won't run. Return an empty string, for consistent type return
-  return match ? transitions[match] : "";
+  return match ? transitions[match] : '';
 }
 
 export const getRelativeBoundingBox = ({
   childDomNode,
   parentDomNode,
-  getPosition
+  getPosition,
 }: {
   childDomNode: HTMLElement,
   parentDomNode: HTMLElement,
-  getPosition: GetPosition
+  getPosition: GetPosition,
 }): ClientRect => {
   const parentBox = getPosition(parentDomNode);
   const { top, left, right, bottom, width, height } = getPosition(childDomNode);
@@ -61,7 +76,7 @@ export const getRelativeBoundingBox = ({
     right: parentBox.right - right,
     bottom: parentBox.bottom - bottom,
     width,
-    height
+    height,
   };
 };
 
@@ -74,12 +89,12 @@ export const getPositionDelta = ({
   childDomNode,
   childBoundingBox,
   parentBoundingBox,
-  getPosition
+  getPosition,
 }: {
   childDomNode: HTMLElement,
   childBoundingBox: ?ClientRect,
   parentBoundingBox: ?ClientRect,
-  getPosition: GetPosition
+  getPosition: GetPosition,
 }): [number, number] => {
   // TEMP: A mystery bug is sometimes causing unnecessary boundingBoxes to
   // remain. Until this bug can be solved, this band-aid fix does the job:
@@ -89,7 +104,7 @@ export const getPositionDelta = ({
     right: 0,
     bottom: 0,
     height: 0,
-    width: 0
+    width: 0,
   };
 
   // Our old box is its last calculated position, derived on mount or at the
@@ -104,10 +119,13 @@ export const getPositionDelta = ({
   const newAbsoluteBox = getPosition(childDomNode);
   const newRelativeBox = {
     top: newAbsoluteBox.top - parentBox.top,
-    left: newAbsoluteBox.left - parentBox.left
+    left: newAbsoluteBox.left - parentBox.left,
   };
 
-  return [oldRelativeBox.left - newRelativeBox.left, oldRelativeBox.top - newRelativeBox.top];
+  return [
+    oldRelativeBox.left - newRelativeBox.left,
+    oldRelativeBox.top - newRelativeBox.top,
+  ];
 };
 
 /** removeNodeFromDOMFlow
@@ -120,7 +138,10 @@ export const getPositionDelta = ({
  *
  * This is a vital part of the FLIP technique.
  */
-export const removeNodeFromDOMFlow = (childData: NodeData, verticalAlignment: VerticalAlignment) => {
+export const removeNodeFromDOMFlow = (
+  childData: NodeData,
+  verticalAlignment: VerticalAlignment,
+) => {
   const { domNode, boundingBox } = childData;
 
   if (!domNode || !boundingBox) {
@@ -132,15 +153,15 @@ export const removeNodeFromDOMFlow = (childData: NodeData, verticalAlignment: Ve
 
   // We need to clean up margins, by converting and removing suffix:
   // eg. '21px' -> 21
-  const marginAttrs = ["margin-top", "margin-left", "margin-right"];
+  const marginAttrs = ['margin-top', 'margin-left', 'margin-right'];
   const margins: {
-    [string]: number
+    [string]: number,
   } = marginAttrs.reduce((acc, margin) => {
     const propertyVal = computed.getPropertyValue(margin);
 
     return {
       ...acc,
-      [margin]: Number(propertyVal.replace("px", ""))
+      [margin]: Number(propertyVal.replace('px', '')),
     };
   }, {});
 
@@ -148,13 +169,16 @@ export const removeNodeFromDOMFlow = (childData: NodeData, verticalAlignment: Ve
   // top offset. This is because, when the container is bottom-aligned, its
   // height shrinks from the top, not the bottom. We're removing this node
   // from the flow, so the top is going to drop by its height.
-  const topOffset = verticalAlignment === "bottom" ? boundingBox.top - boundingBox.height : boundingBox.top;
+  const topOffset =
+    verticalAlignment === 'bottom'
+      ? boundingBox.top - boundingBox.height
+      : boundingBox.top;
 
   const styles: Styles = {
-    position: "absolute",
-    top: `${topOffset - margins["margin-top"]}px`,
-    left: `${boundingBox.left - margins["margin-left"]}px`,
-    right: `${boundingBox.right - margins["margin-right"]}px`
+    position: 'absolute',
+    top: `${topOffset - margins['margin-top']}px`,
+    left: `${boundingBox.left - margins['margin-left']}px`,
+    right: `${boundingBox.right - margins['margin-right']}px`,
   };
 
   applyStylesToDOMNode({ domNode, styles });
@@ -166,7 +190,15 @@ export const removeNodeFromDOMFlow = (childData: NodeData, verticalAlignment: Ve
  * container doesn't collapse when its children are removed from the
  * document flow.
  */
-export const updateHeightPlaceholder = ({ domNode, parentData, getPosition }: { domNode: HTMLElement, parentData: NodeData, getPosition: GetPosition }) => {
+export const updateHeightPlaceholder = ({
+  domNode,
+  parentData,
+  getPosition,
+}: {
+  domNode: HTMLElement,
+  parentData: NodeData,
+  getPosition: GetPosition,
+}) => {
   const parentDomNode = parentData.domNode;
   const parentBoundingBox = parentData.boundingBox;
 
@@ -179,7 +211,7 @@ export const updateHeightPlaceholder = ({ domNode, parentData, getPosition }: { 
   // we first set its height to 0.
   // This allows the container to collapse down to the size of just its
   // content (plus container padding or borders if any).
-  applyStylesToDOMNode({ domNode, styles: { height: "0" } });
+  applyStylesToDOMNode({ domNode, styles: { height: '0' } });
 
   // Find the distance by which the container would be collapsed by elements
   // leaving. We compare the freshly-available parent height with the original,
@@ -192,7 +224,7 @@ export const updateHeightPlaceholder = ({ domNode, parentData, getPosition }: { 
   // height to take up the difference. Otherwise set its height to zero,
   // so that it has no effect.
   const styles: Styles = {
-    height: reductionInHeight > 0 ? `${reductionInHeight}px` : "0"
+    height: reductionInHeight > 0 ? `${reductionInHeight}px` : '0',
   };
 
   applyStylesToDOMNode({ domNode, styles });
@@ -200,7 +232,7 @@ export const updateHeightPlaceholder = ({ domNode, parentData, getPosition }: { 
 
 export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
   // When running in a windowless environment, abort!
-  if (typeof HTMLElement === "undefined") {
+  if (typeof HTMLElement === 'undefined') {
     return null;
   }
 
@@ -222,14 +254,19 @@ export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
   return foundNode;
 };
 
-export const createTransitionString = (index: number, props: ConvertedProps): string => {
+export const createTransitionString = (
+  index: number,
+  props: ConvertedProps,
+): string => {
   let { delay, duration } = props;
   const { staggerDurationBy, staggerDelayBy, easing } = props;
 
   delay += index * staggerDelayBy;
   duration += index * staggerDurationBy;
 
-  const cssProperties = ["transform", "opacity"];
+  const cssProperties = ['transform', 'opacity'];
 
-  return cssProperties.map(prop => `${prop} ${duration}ms ${easing} ${delay}ms`).join(", ");
+  return cssProperties
+    .map(prop => `${prop} ${duration}ms ${easing} ${delay}ms`)
+    .join(', ');
 };

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -7,26 +7,13 @@
  * They almost always have side effects, and will hopefully become the
  * only spot in the codebase with impure functions.
  */
-import { findDOMNode } from 'react-dom';
-import type { ElementRef } from 'react';
+import { findDOMNode } from "react-dom";
+import type { ElementRef } from "react";
 
-import { hyphenate } from './helpers';
-import type {
-  Styles,
-  ClientRect,
-  GetPosition,
-  NodeData,
-  VerticalAlignment,
-  ConvertedProps,
-} from './typings';
+import { hyphenate } from "./helpers";
+import type { Styles, ClientRect, GetPosition, NodeData, VerticalAlignment, ConvertedProps } from "./typings";
 
-export function applyStylesToDOMNode({
-  domNode,
-  styles,
-}: {
-  domNode: HTMLElement,
-  styles: Styles,
-}) {
+export function applyStylesToDOMNode({ domNode, styles }: { domNode: HTMLElement, styles: Styles }) {
   // Can't just do an object merge because domNode.styles is no regular object.
   // Need to do it this way for the engine to fire its `set` listeners.
   Object.keys(styles).forEach(key => {
@@ -37,35 +24,33 @@ export function applyStylesToDOMNode({
 // Modified from Modernizr
 export function whichTransitionEvent(): string {
   const transitions = {
-    transition: 'transitionend',
-    '-o-transition': 'oTransitionEnd',
-    '-moz-transition': 'transitionend',
-    '-webkit-transition': 'webkitTransitionEnd',
+    transition: "transitionend",
+    "-o-transition": "oTransitionEnd",
+    "-moz-transition": "transitionend",
+    "-webkit-transition": "webkitTransitionEnd"
   };
 
   // If we're running in a browserless environment (eg. SSR), it doesn't apply.
   // Return a placeholder string, for consistent type return.
-  if (typeof document === 'undefined') return '';
+  if (typeof document === "undefined") return "";
 
-  const el = document.createElement('fakeelement');
+  const el = document.createElement("fakeelement");
 
-  const match = Object.keys(transitions).find(
-    t => el.style.getPropertyValue(t) !== undefined,
-  );
+  const match = Object.keys(transitions).find(t => el.style.getPropertyValue(t) !== undefined);
 
   // If no `transition` is found, we must be running in a browser so ancient,
   // React itself won't run. Return an empty string, for consistent type return
-  return match ? transitions[match] : '';
+  return match ? transitions[match] : "";
 }
 
 export const getRelativeBoundingBox = ({
   childDomNode,
   parentDomNode,
-  getPosition,
+  getPosition
 }: {
   childDomNode: HTMLElement,
   parentDomNode: HTMLElement,
-  getPosition: GetPosition,
+  getPosition: GetPosition
 }): ClientRect => {
   const parentBox = getPosition(parentDomNode);
   const { top, left, right, bottom, width, height } = getPosition(childDomNode);
@@ -76,7 +61,7 @@ export const getRelativeBoundingBox = ({
     right: parentBox.right - right,
     bottom: parentBox.bottom - bottom,
     width,
-    height,
+    height
   };
 };
 
@@ -89,12 +74,12 @@ export const getPositionDelta = ({
   childDomNode,
   childBoundingBox,
   parentBoundingBox,
-  getPosition,
+  getPosition
 }: {
   childDomNode: HTMLElement,
   childBoundingBox: ?ClientRect,
   parentBoundingBox: ?ClientRect,
-  getPosition: GetPosition,
+  getPosition: GetPosition
 }): [number, number] => {
   // TEMP: A mystery bug is sometimes causing unnecessary boundingBoxes to
   // remain. Until this bug can be solved, this band-aid fix does the job:
@@ -104,7 +89,7 @@ export const getPositionDelta = ({
     right: 0,
     bottom: 0,
     height: 0,
-    width: 0,
+    width: 0
   };
 
   // Our old box is its last calculated position, derived on mount or at the
@@ -119,13 +104,10 @@ export const getPositionDelta = ({
   const newAbsoluteBox = getPosition(childDomNode);
   const newRelativeBox = {
     top: newAbsoluteBox.top - parentBox.top,
-    left: newAbsoluteBox.left - parentBox.left,
+    left: newAbsoluteBox.left - parentBox.left
   };
 
-  return [
-    oldRelativeBox.left - newRelativeBox.left,
-    oldRelativeBox.top - newRelativeBox.top,
-  ];
+  return [oldRelativeBox.left - newRelativeBox.left, oldRelativeBox.top - newRelativeBox.top];
 };
 
 /** removeNodeFromDOMFlow
@@ -138,10 +120,7 @@ export const getPositionDelta = ({
  *
  * This is a vital part of the FLIP technique.
  */
-export const removeNodeFromDOMFlow = (
-  childData: NodeData,
-  verticalAlignment: VerticalAlignment,
-) => {
+export const removeNodeFromDOMFlow = (childData: NodeData, verticalAlignment: VerticalAlignment) => {
   const { domNode, boundingBox } = childData;
 
   if (!domNode || !boundingBox) {
@@ -153,15 +132,15 @@ export const removeNodeFromDOMFlow = (
 
   // We need to clean up margins, by converting and removing suffix:
   // eg. '21px' -> 21
-  const marginAttrs = ['margin-top', 'margin-left', 'margin-right'];
+  const marginAttrs = ["margin-top", "margin-left", "margin-right"];
   const margins: {
-    [string]: number,
+    [string]: number
   } = marginAttrs.reduce((acc, margin) => {
     const propertyVal = computed.getPropertyValue(margin);
 
     return {
       ...acc,
-      [margin]: Number(propertyVal.replace('px', '')),
+      [margin]: Number(propertyVal.replace("px", ""))
     };
   }, {});
 
@@ -169,16 +148,13 @@ export const removeNodeFromDOMFlow = (
   // top offset. This is because, when the container is bottom-aligned, its
   // height shrinks from the top, not the bottom. We're removing this node
   // from the flow, so the top is going to drop by its height.
-  const topOffset =
-    verticalAlignment === 'bottom'
-      ? boundingBox.top - boundingBox.height
-      : boundingBox.top;
+  const topOffset = verticalAlignment === "bottom" ? boundingBox.top - boundingBox.height : boundingBox.top;
 
   const styles: Styles = {
-    position: 'absolute',
-    top: `${topOffset - margins['margin-top']}px`,
-    left: `${boundingBox.left - margins['margin-left']}px`,
-    right: `${boundingBox.right - margins['margin-right']}px`,
+    position: "absolute",
+    top: `${topOffset - margins["margin-top"]}px`,
+    left: `${boundingBox.left - margins["margin-left"]}px`,
+    right: `${boundingBox.right - margins["margin-right"]}px`
   };
 
   applyStylesToDOMNode({ domNode, styles });
@@ -190,15 +166,7 @@ export const removeNodeFromDOMFlow = (
  * container doesn't collapse when its children are removed from the
  * document flow.
  */
-export const updateHeightPlaceholder = ({
-  domNode,
-  parentData,
-  getPosition,
-}: {
-  domNode: HTMLElement,
-  parentData: NodeData,
-  getPosition: GetPosition,
-}) => {
+export const updateHeightPlaceholder = ({ domNode, parentData, getPosition }: { domNode: HTMLElement, parentData: NodeData, getPosition: GetPosition }) => {
   const parentDomNode = parentData.domNode;
   const parentBoundingBox = parentData.boundingBox;
 
@@ -211,7 +179,7 @@ export const updateHeightPlaceholder = ({
   // we first set its height to 0.
   // This allows the container to collapse down to the size of just its
   // content (plus container padding or borders if any).
-  applyStylesToDOMNode({ domNode, styles: { height: '0' } });
+  applyStylesToDOMNode({ domNode, styles: { height: "0" } });
 
   // Find the distance by which the container would be collapsed by elements
   // leaving. We compare the freshly-available parent height with the original,
@@ -224,7 +192,7 @@ export const updateHeightPlaceholder = ({
   // height to take up the difference. Otherwise set its height to zero,
   // so that it has no effect.
   const styles: Styles = {
-    height: reductionInHeight > 0 ? `${reductionInHeight}px` : '0',
+    height: reductionInHeight > 0 ? `${reductionInHeight}px` : "0"
   };
 
   applyStylesToDOMNode({ domNode, styles });
@@ -232,7 +200,7 @@ export const updateHeightPlaceholder = ({
 
 export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
   // When running in a windowless environment, abort!
-  if (typeof HTMLElement === 'undefined') {
+  if (typeof HTMLElement === "undefined") {
     return null;
   }
 
@@ -246,7 +214,7 @@ export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
   // composite components.
   const foundNode: ?(Element | Text) = findDOMNode(element);
 
-  if (!(foundNode instanceof HTMLElement)) {
+  if (foundNode.nodeType === Node.TEXT_NODE) {
     // Text nodes are not supported
     return null;
   }
@@ -254,19 +222,14 @@ export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
   return foundNode;
 };
 
-export const createTransitionString = (
-  index: number,
-  props: ConvertedProps,
-): string => {
+export const createTransitionString = (index: number, props: ConvertedProps): string => {
   let { delay, duration } = props;
   const { staggerDurationBy, staggerDelayBy, easing } = props;
 
   delay += index * staggerDelayBy;
   duration += index * staggerDurationBy;
 
-  const cssProperties = ['transform', 'opacity'];
+  const cssProperties = ["transform", "opacity"];
 
-  return cssProperties
-    .map(prop => `${prop} ${duration}ms ${easing} ${delay}ms`)
-    .join(', ');
+  return cssProperties.map(prop => `${prop} ${duration}ms ${easing} ${delay}ms`).join(", ");
 };

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -22,7 +22,7 @@ Please wrap your components in a native element (eg. <div>), or a non-functional
 export const primitiveNodeSupplied = warnOnce(`
 >> Error, via react-flip-move <<
 
-You provided a primitive (text or number) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
+You provided a primitive (text, number, or boolean) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
 
 Please wrap your value in a native element (eg. <span>), or a component.
 `);

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -90,8 +90,7 @@ function propConverter(
       // If the child doesn't have a key, it means we aren't animating it.
       // It's allowed to be an SFC, since we ignore it.
       Children.forEach(children, (child: Child) => {
-        // null, undefined, and booleans will be filtered out by Children.toArray
-        if (child == null || typeof child === 'boolean') {
+        if (child == null) {
           return;
         }
 

--- a/src/typings.js
+++ b/src/typings.js
@@ -1,7 +1,6 @@
 // @flow
 import type { Element } from 'react';
 import type {
-  Child,
   Styles,
   Animation,
   Presets,
@@ -17,7 +16,6 @@ import type {
 } from 'react-flip-move'; // eslint-disable-line import/extensions
 
 export type {
-  Child,
   Styles,
   Animation,
   Presets,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -340,7 +340,7 @@ Please wrap your components in a native element (eg. <div>), or a non-functional
         expect(warnStub).to.have.been.calledWith(`
 >> Error, via react-flip-move <<
 
-You provided a primitive (text or number) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
+You provided a primitive (text, number, or boolean) node as a child to <FlipMove>. Flip Move needs containers with unique keys to move children around.
 
 Please wrap your value in a native element (eg. <span>), or a component.
 `);


### PR DESCRIPTION
getNativeNode checks if element is instanceOf HTMLEment, which doesn't work if the FlipMove component is rendered inside an iFrame using React Portal.

Checked getNativeNode to check absolutely if node is a text node.