### PR TITLE
do absolute check for node type

### DIFF
--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -250,8 +250,8 @@ export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
     // Text nodes are not supported
     return null;
   }
-
-  return foundNode;
+  // eslint-disable-next-line flowtype/no-weak-types
+  return ((foundNode: any): ?HTMLElement);
 };
 
 export const createTransitionString = (

--- a/src/dom-manipulation.js
+++ b/src/dom-manipulation.js
@@ -246,7 +246,7 @@ export const getNativeNode = (element: ElementRef<*>): ?HTMLElement => {
   // composite components.
   const foundNode: ?(Element | Text) = findDOMNode(element);
 
-  if (!(foundNode instanceof HTMLElement)) {
+  if (foundNode && foundNode.nodeType === Node.TEXT_NODE) {
     // Text nodes are not supported
     return null;
   }


### PR DESCRIPTION
getNativeNode checks if element is instanceOf HTMLEment, which doesn't work if the FlipMove component is rendered inside an iFrame using React Portal.

Changed getNativeNode to check absolutely if node is a text node.

This is a resubmission, stopped jsprettier from polluting file and added type refinement to satisfy flow.