### PR TITLE
Fix on IE10

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -61,7 +61,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
   // of truth.
   state = {
     children: getElementChildren(
-      this.props.children,
+      this.props? this.props.children: [],
     ).map((element: Element<*>) => ({
       ...element,
       element,


### PR DESCRIPTION
The `props` property doesn't seem to be initialized at this point when creating a <FlipMove> component, which leads to an error.