### PR TITLE
Add position: relative to static parents in wrapperless mode

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -13,6 +13,7 @@ import ReactDOM from 'react-dom';
 // eslint-disable-next-line no-duplicate-imports
 import type { Element, ElementRef, Key, ChildrenArray } from 'react';
 
+import { parentNodePositionStatic } from './error-messages';
 import './polyfills';
 import propConverter from './prop-converter';
 import {
@@ -194,6 +195,14 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     // This ought to be impossible, but handling it for Flow's sake.
     if (!parentNode || !(parentNode instanceof HTMLElement)) {
       return;
+    }
+
+    // If the parent node has static positioning, leave animations might look
+    // really funky. Let's automatically apply `position: relative` in this
+    // case, to prevent any quirkiness.
+    if (window.getComputedStyle(parentNode).position === 'static') {
+      parentNode.style.position = 'relative';
+      parentNodePositionStatic();
     }
 
     this.parentData.domNode = parentNode;

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -62,3 +62,13 @@ The enter/leave preset you provided is invalid. We don't currently have a '${arg
 
 Acceptable values are ${args.acceptableValues}. The default value of '${args.defaultValue}' will be used.
 `);
+
+export const parentNodePositionStatic = warnOnce(`
+>> Warning, via react-flip-move <<
+
+When using "wrapperless" mode (by supplying 'typeName' of 'null'), strange things happen when the direct parent has the default "static" position.
+
+FlipMove has added 'position: relative' to this node, to ensure Flip Move animates correctly.
+
+To avoid seeing this warning, simply apply a non-static position to that parent node.
+`);

--- a/stories/misc.stories.js
+++ b/stories/misc.stories.js
@@ -103,3 +103,49 @@ import FlipMoveListItem from './helpers/FlipMoveListItem';
       );
     });
 });
+
+storiesOf('Misc - wrapperless', module).add('within a static <div>', () => {
+  // eslint-disable-next-line react/no-multi-comp
+  class CustomComponent extends Component {
+    state = {
+      items: ['hello', 'world', 'how', 'are', 'you'],
+    };
+
+    componentDidMount() {
+      this.intervalId = window.setInterval(() => {
+        const { items } = this.state;
+
+        if (items.length === 0) {
+          return;
+        }
+
+        this.setState({
+          items: items.slice(0, items.length - 1),
+        });
+      }, 1000);
+    }
+
+    componentWillUnmount() {
+      window.clearInterval(this.intervalId);
+    }
+
+    render() {
+      return (
+        <div
+          style={{
+            color: 'red',
+            marginLeft: 100,
+            marginTop: 200,
+            border: '1px solid blue',
+          }}
+        >
+          <FlipMove typeName={null}>
+            {this.state.items.map(item => <div key={item}>{item}</div>)}
+          </FlipMove>
+        </div>
+      );
+    }
+  }
+
+  return <CustomComponent />;
+});


### PR DESCRIPTION
Quick update to enforce a non-static position on the parent container in wrapperless mode. Issues a warning so that the user knows what's up.