### PR TITLE
Fix typescript typings and documentation section of typeName prop

### DIFF
--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -279,7 +279,7 @@ In general, it is advisable to ignore the `domNodes` argument and work with the 
 
 | **Accepted Types:**  | **Default Value** |
 |----------------------|-------------------|
-|  `String` | `null`   | 'div'             |
+|  `String`, `null`    | 'div'             |
 
 
 Flip Move wraps your children in a container element. By default, this element is a `div`, but you may wish to provide a custom HTML element (for example, if your children are list items, you may wish to set this to `ul`).

--- a/typings/react-flip-move.d.ts
+++ b/typings/react-flip-move.d.ts
@@ -206,7 +206,7 @@ declare namespace FlipMove {
          *
          * @default "div"
          */
-        typeName?: string;
+        typeName?: string | null;
 
         /**
          * Sometimes, you may wish to temporarily disable the animations and have the normal behaviour resumed. Setting this


### PR DESCRIPTION
In readme it is mentioned that typeName accepts `null`. Previous typings did not allow to use it.

Also, there was a typo in documentation concerning typeName. Previously it was rendered like `null` was a default value.