### PR TITLE
Increasing performance by avoiding styles recalculations

### DIFF
--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -217,10 +217,10 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     const childrenInitialStyles = dynamicChildren.map(child =>
       this.computeInitialStyles(child),
     );
-    dynamicChildren.forEach((child, n) => {
+    dynamicChildren.forEach((child, index) => {
       this.remainingAnimations += 1;
       this.childrenToAnimate.push(getKey(child));
-      this.animateChild(child, n, childrenInitialStyles);
+      this.animateChild(child, index, childrenInitialStyles[index]);
     });
 
     if (typeof this.props.onStartAll === 'function') {
@@ -386,11 +386,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     });
   }
 
-  animateChild(
-    child: ChildData,
-    index: number,
-    childrenInitialStyles: Styles[],
-  ) {
+  animateChild(child: ChildData, index: number, childInitialStyles: Styles) {
     const { domNode } = this.getChildData(getKey(child));
     if (!domNode) {
       return;
@@ -404,7 +400,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     // In FLIP terminology, this is the 'Invert' stage.
     applyStylesToDOMNode({
       domNode,
-      styles: childrenInitialStyles[index],
+      styles: childInitialStyles,
     });
 
     // Start by invoking the onStart callback for this child.
@@ -570,7 +566,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
       // It is possible that a child does not have a `key` property;
       // Ignore these children, they don't need to be moved.
       if (!childKey) {
-        childrenBoundingBoxes.push();
+        childrenBoundingBoxes.push(null);
         return;
       }
 
@@ -578,7 +574,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
       // populated for certain children. In this case, avoid doing this update.
       // see: https://github.com/joshwcomeau/react-flip-move/pull/91
       if (!this.hasChildData(childKey)) {
-        childrenBoundingBoxes.push();
+        childrenBoundingBoxes.push(null);
         return;
       }
 
@@ -587,7 +583,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
       // If the child element returns null, we need to avoid trying to
       // account for it
       if (!childData.domNode || !child) {
-        childrenBoundingBoxes.push();
+        childrenBoundingBoxes.push(null);
         return;
       }
 
@@ -603,12 +599,14 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     this.state.children.forEach((child, index) => {
       const childKey = getKey(child);
 
-      if (!childKey || !childrenBoundingBoxes[index]) {
+      const childBoundingBox = childrenBoundingBoxes[index];
+
+      if (!childKey) {
         return;
       }
 
       this.setChildData(childKey, {
-        boundingBox: childrenBoundingBoxes[index],
+        boundingBox: childBoundingBox,
       });
     });
   }


### PR DESCRIPTION
In my project I have faced performance issues: it took about 700ms to process animations for a list with 30 elements. I noticed styles recalculations took the biggest part of it.

![image](https://user-images.githubusercontent.com/6253488/34522071-034308b2-f0a2-11e7-8791-737fefe4b9bf.png)

It was mentioned (e.g. [here](http://gent.ilcore.com/2011/03/how-not-to-trigger-layout-in-webkit.html)) that DOM calculated sizes functions should be used with caution. To achieve highest performance reads and writes should be performed in batches.

After applying some changes time to rerender the list reduced by 4 times.

![image](https://user-images.githubusercontent.com/6253488/34522403-793c9410-f0a3-11e7-8790-bc8e7baf4501.png)
