### PR TITLE
Warn if children are disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "prebuild": "npm run lint && flow check && npm run typescript && npm run test",
     "prepublishOnly": "npm run build",
     "prepush": "npm run prebuild",
-    "test": "NODE_ENV=test ./node_modules/.bin/karma start --single-run",
+    "test": "cross-env NODE_ENV=test ./node_modules/.bin/karma start --single-run",
     "test:dev": "karma start karma.conf.js",
     "tslint": "tslint typings/*.tsx typings/*.ts",
     "typescript": "npm run tslint && tsc typings/test.tsx --noEmit --jsx react --target es6 --module es2015 --moduleResolution node",
     "storybook": "start-storybook -p 9001",
-    "storybook:preact": "REACT_IMPL=preact npm run storybook"
+    "storybook:preact": "cross-env REACT_IMPL=preact npm run storybook"
   },
   "author": "Joshua Comeau <joshwcomeau@gmail.com>",
   "license": "MIT",
@@ -67,6 +67,7 @@
     "babel-preset-stage-0": "6.24.1",
     "chai": "4.1.2",
     "create-react-class": "15.6.2",
+    "cross-env": "^5.1.3",
     "enzyme": "3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",
     "eslint": "3.10.0",

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -13,7 +13,7 @@ import ReactDOM from 'react-dom';
 // eslint-disable-next-line no-duplicate-imports
 import type { Element, ElementRef, Key, ChildrenArray } from 'react';
 
-import { parentNodePositionStatic } from './error-messages';
+import { parentNodePositionStatic, childIsDisabled } from './error-messages';
 import './polyfills';
 import propConverter from './prop-converter';
 import {
@@ -347,6 +347,14 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
 
       leavingChildren.forEach(leavingChild => {
         const childData = this.getChildData(getKey(leavingChild));
+
+        // Warn if child is disabled
+        if (
+          !this.isAnimationDisabled(this.props) &&
+          childData.domNode &&
+          childData.domNode.disabled
+        )
+          childIsDisabled();
 
         // We need to take the items out of the "flow" of the document, so that
         // its siblings can move to take its place.

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -353,8 +353,9 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
           !this.isAnimationDisabled(this.props) &&
           childData.domNode &&
           childData.domNode.disabled
-        )
+        ) {
           childIsDisabled();
+        }
 
         // We need to take the items out of the "flow" of the document, so that
         // its siblings can move to take its place.

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -72,3 +72,11 @@ FlipMove has added 'position: relative' to this node, to ensure Flip Move animat
 
 To avoid seeing this warning, simply apply a non-static position to that parent node.
 `);
+
+export const childIsDisabled = warnOnce(`
+>> Warning, via react-flip-move <<
+
+One or more of Flip Move's child elements have the html attribute 'disabled' set to true.
+
+Please note that this will cause animations to break in Internet Explorer 11 and below. Either remove the disabled attribute or set 'animation' to false.
+`);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -408,6 +408,64 @@ Please wrap your value in a native element (eg. <span>), or a component.
         );
         expect(warnStub).to.not.have.been.called;
       });
+
+      it('warns when child has disabled attribute', () => {
+        const items = [
+          <button disabled key="1" />,
+          <button disabled key="2" />,
+        ];
+
+        class ButtonList extends Component {
+          state = {
+            items,
+          };
+
+          render() {
+            return <FlipMove>{this.state.items}</FlipMove>;
+          }
+        }
+
+        const component = mount(<ButtonList />);
+        component.setState({
+          items: [items[0]],
+        });
+        expect(warnStub).to.have.been.calledWith(`
+>> Warning, via react-flip-move <<
+
+One or more of Flip Move's child elements have the html attribute 'disabled' set to true.
+
+Please note that this will cause animations to break in Internet Explorer 11 and below. Either remove the disabled attribute or set 'animation' to false.
+`);
+      });
+
+      it("doesn't when child has disabled attribute", () => {
+        const items = [
+          <button disabled key="1" />,
+          <button disabled key="2" />,
+        ];
+
+        class ButtonList extends Component {
+          state = {
+            items,
+          };
+
+          render() {
+            return <FlipMove disableAllAnimations>{this.state.items}</FlipMove>;
+          }
+        }
+
+        const component = mount(<ButtonList />);
+        component.setState({
+          items: [items[0]],
+        });
+        expect(warnStub).not.to.have.been.calledWith(`
+>> Warning, via react-flip-move <<
+
+One or more of Flip Move's child elements have the html attribute 'disabled' set to true.
+
+Please note that this will cause animations to break in Internet Explorer 11 and below. Either remove the disabled attribute or set 'animation' to false.
+`);
+      });
     });
 
     describe('falsy children', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -438,7 +438,7 @@ Please note that this will cause animations to break in Internet Explorer 11 and
 `);
       });
 
-      it("doesn't when child has disabled attribute", () => {
+      it("doesn't warn when child has disabled attribute if animations are disabled", () => {
         const items = [
           <button disabled key="1" />,
           <button disabled key="2" />,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,7 +2295,14 @@ create-react-class@15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-spawn@^5.0.1:
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -4194,6 +4201,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
In Internet Explorer 11 (and below), the `transitonend` event will not (consistently) fire for elements that have the `disabled` attribute. This means the callback for node removal is never fired and the supposedly removed nodes stay in the html.

This PR adds a new warning to inform about this quirk. Before a node is removed, the list children are checked for `disabled`. If one or more are found and animations are not disabled, the warning emits.

ps.: this also takes care of the cleanup issue i mentioned [here](https://github.com/joshwcomeau/react-flip-move/issues/209#issuecomment-354853118)
  
  