### PR TITLE
Make link to blog post more prominent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ CSS transitions only work for CSS properties. If your list is shuffled, the item
 
 Flip Move uses the [_FLIP technique_](https://aerotwist.com/blog/flip-your-animations/#the-general-approach) to work out what such a transition would look like, and fakes it using 60+ FPS hardware-accelerated CSS transforms.
 
+[**Read more about how it works**](https://medium.com/developers-writing/animating-the-unanimatable-1346a5aab3cd)
+
 [![demo](https://s3.amazonaws.com/githubdocs/fm-main-demo.gif)](http://joshwcomeau.github.io/react-flip-move/examples/#/shuffle)
 
 
@@ -54,8 +56,7 @@ Flip Move was inspired by Ryan Florence's awesome <a href="https://github.com/ry
 
   * Compatible with [Preact](https://preactjs.com/) (should work with other React-like libraries as well).
 
-  * Implementation based on the [_FLIP technique_](https://medium.com/developers-writing/animating-the-unanimatable-1346a5aab3cd), a beautiful-in-its-simplicity method of tackling this problem. UMD build, when minified and gzipped, is under 6kb! ⚡
-
+  * Tiny! Gzipped size is around 6kb! ⚡
 
 
 ## Quickstart


### PR DESCRIPTION
On [Spectrum](https://spectrum.chat/thread/df65e157-d118-40cd-87c8-88bdd3724aa1), the first comment was about how the [Flip Move blog post](https://medium.com/developers-writing/animating-the-unanimatable-1346a5aab3cd) was cool, but hard to find, since I use the same link text earlier for the [Aerotwist post](https://aerotwist.com/blog/flip-your-animations/#the-general-approach) that inspired this project.

This quick fix gives the blog post its own little paragraph. I also tweaked the final bullet-point to be more to-the-point (and to correct the slight lie that it was under 6kb, although with #213 we may soon be able to brag that it's under 4kb!).

I didn't tag any reviewers because I don't want to impose on anyone's time for a copy change, but if anyone has any suggestions about this, please do feel free to comment :) Otherwise I'll merge it in the next day or so.