### PR TITLE
Removed deprecated options

### DIFF
--- a/src/enter-leave-presets.js
+++ b/src/enter-leave-presets.js
@@ -52,18 +52,5 @@ export const leavePresets: Presets = {
 // Assigning a custom export in case we ever want to add appear-specific ones.
 export const appearPresets = enterPresets;
 
-// Embarrassingly enough, v2.0 launched with typo'ed preset names.
-// To avoid penning a new major version over something so inconsequential,
-// we're supporting both spellings. In a future version, these alternatives
-// may be deprecated.
-// $FlowFixMe
-enterPresets.accordianVertical = enterPresets.accordionVertical;
-// $FlowFixMe
-enterPresets.accordianHorizontal = enterPresets.accordionHorizontal;
-// $FlowFixMe
-leavePresets.accordianVertical = leavePresets.accordionVertical;
-// $FlowFixMe
-leavePresets.accordianHorizontal = leavePresets.accordionHorizontal;
-
 export const defaultPreset = 'elevator';
 export const disablePreset = 'none';

--- a/src/error-messages.js
+++ b/src/error-messages.js
@@ -41,14 +41,6 @@ The prop you provided for '${args.prop}' is invalid. It needs to be a positive i
 As a result,  the default value for this parameter will be used, which is '${args.defaultValue}'.
 `);
 
-export const deprecatedDisableAnimations = warnOnce(`
->> Warning, via react-flip-move <<
-
-The 'disableAnimations' prop you provided is deprecated. Please switch to use 'disableAllAnimations'.
-
-This will become a silent error in future versions of react-flip-move.
-`);
-
 export const invalidEnterLeavePreset = (args: {
   value: string,
   acceptableValues: string,

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -22,7 +22,6 @@ import {
   primitiveNodeSupplied,
   invalidTypeForTimingProp,
   invalidEnterLeavePreset,
-  deprecatedDisableAnimations,
 } from './error-messages';
 import {
   appearPresets,
@@ -140,15 +139,6 @@ function propConverter(
 
       this.checkChildren(workingProps.children);
 
-      // Accept `disableAnimations`, but add a deprecation warning
-      if (typeof props.disableAnimations !== 'undefined') {
-        workingProps.disableAllAnimations = props.disableAnimations;
-
-        if (process.env.NODE_ENV !== 'production') {
-          deprecatedDisableAnimations();
-        }
-      }
-
       // Gather any additional props;
       // they will be delegated to the ReactElement created.
       const primaryPropKeys = Object.keys(workingProps);
@@ -209,9 +199,7 @@ function propConverter(
             if (process.env.NODE_ENV !== 'production') {
               invalidEnterLeavePreset({
                 value: animation,
-                acceptableValues: presetKeys
-                  .filter(key => key.indexOf('accordian') === -1)
-                  .join(', '),
+                acceptableValues: presetKeys.join(', '),
                 defaultValue: defaultPreset,
               });
             }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -318,7 +318,6 @@ describe('FlipMove', () => {
         </FlipMove>,
       );
       shallow(<FlipMove>hi</FlipMove>);
-      shallow(<FlipMove disableAnimations />);
       shallow(<FlipMove duration="hi" />);
       shallow(<FlipMove appearAnimation="unknown" />);
 
@@ -486,20 +485,6 @@ Please note that this will cause animations to break in Internet Explorer 11 and
           done();
         }, 750);
       });
-    });
-
-    it('warns once about deprecated disableAnimations prop', () => {
-      shallow(<FlipMove disableAnimations />);
-      const wrapper = shallow(<FlipMove disableAnimations />);
-      expect(warnStub).to.have.been.calledOnce;
-      expect(warnStub).to.have.been.calledWith(`
->> Warning, via react-flip-move <<
-
-The 'disableAnimations' prop you provided is deprecated. Please switch to use 'disableAllAnimations'.
-
-This will become a silent error in future versions of react-flip-move.
-`);
-      expect(wrapper.prop('disableAllAnimations')).to.equal(true);
     });
 
     describe('animation props', () => {


### PR DESCRIPTION
That lands us at **4905** - and actually this includes UMD wrapper (because I test `dist/react-flip-move.min.js`), so the actual size in apps will be slightly smaller