### PR TITLE
Add babelrc for storybook

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,7 +1,3 @@
 {
-  "presets": ["react", "env", "stage-0", "flow"],
-  "plugins": [
-     "transform-decorators-legacy",
-     "add-module-exports"
-  ]
+  "extends": "../.babelrc"
 }

--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -3,16 +3,5 @@
   "plugins": [
      "transform-decorators-legacy",
      "add-module-exports"
-  ],
-  "env": {
-     "test": {
-        "plugins": [
-           ["istanbul", {
-              "exclude": [
-                 "test/**/*.js"
-              ]
-           }]
-        ]
-     }
-  }
+  ]
 }

--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,18 @@
+{
+  "presets": ["react", "env", "stage-0", "flow"],
+  "plugins": [
+     "transform-decorators-legacy",
+     "add-module-exports"
+  ],
+  "env": {
+     "test": {
+        "plugins": [
+           ["istanbul", {
+              "exclude": [
+                 "test/**/*.js"
+              ]
+           }]
+        ]
+     }
+  }
+}


### PR DESCRIPTION
When running React Storybook locally, I was getting the following error:

```
ERROR in ./.storybook/config.js
Module build failed: Error: Couldn't find preset "./.babelrc.js" relative to directory "/Users/joshu/work/flip-move/.storybook"
```

This is easy enough to understand; our `.babelrc` file now looks like this:

```json
{
   "presets": ["./.babelrc.js"]
}
```

It appears that for some reason, Storybook config is trying to load this relative to the storybook dir, and failing to find it there.

I tried creating a new `.babelrc` file inside `.storybook`, and simply pointing it to `../.babelrc.js`, but then it fails with a similar error, trying to open it from a subdirectory:

```
ERROR in ./stories/helpers/FlipMoveListItem.js
Module build failed: Error: Couldn't find preset "../.babelrc.js" relative to directory "/Users/joshu/work/flip-move/stories/helpers"
```

I tried making the path an absolute path with `/.babelrc.js`, no luck.

So yeah, my final solution is just to resurrect the former `.babelrc`, just for storybook. This is obviously kind of a gross solution!

Because it's a dev-only concern and I wanna get the major version shipped, I may just merge this and deal with it in a subsequent PR, but @Andarist or @Hypnosphi or anyone else, if you have any clues as to how to get Storybook to read .babelrc from the same relative root every time, I'd love to kill this and have both files point to the same `.babelrc.js`.