### PR TITLE
Fix TypeScript export type

### DIFF
--- a/typings/react-flip-move.d.ts
+++ b/typings/react-flip-move.d.ts
@@ -7,7 +7,7 @@
 import { Component, ReactElement } from 'react';
 
 export as namespace FlipMove;
-export = FlipMove;
+export default FlipMove;
 
 declare class FlipMove extends Component<FlipMove.FlipMoveProps, any> { }
 

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -1,7 +1,7 @@
 // tslint:disable:max-classes-per-file
 
 import * as React from 'react';
-import * as FlipMove from '..';
+import FlipMove from '..';
 
 function childHook(el: React.ReactElement<any>, node: HTMLElement) {}
 function childrenHook(els: Array<React.ReactElement<any>>, nodes: Array<HTMLElement>) {}


### PR DESCRIPTION
This should fix react-flip-move for TypeScript users. Replaces #220.