### PR TITLE
add custom createTransitionString function

### DIFF
--- a/flow-typed/react-flip-move_v2.9.x-v2.10.x.js
+++ b/flow-typed/react-flip-move_v2.9.x-v2.10.x.js
@@ -62,6 +62,7 @@ declare module 'react-flip-move' {
     getPosition: GetPosition,
     maintainContainerHeight: boolean,
     verticalAlignment: VerticalAlignment,
+    createTransitionString: (index: number) => string,
   };
 
   declare type PolymorphicProps = {

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -431,8 +431,14 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
         // to its new position.
 
         // eslint-disable-next-line flowtype/require-variable-type
+        let transition = '';
+        if (this.props.createTransitionString) {
+          transition = this.props.createTransitionString(index);
+        } else {
+          transition = createTransitionString(index, this.props);
+        }
         let styles = {
-          transition: createTransitionString(index, this.props),
+          transition,
           transform: '',
           opacity: '',
         };

--- a/src/prop-converter.js
+++ b/src/prop-converter.js
@@ -111,6 +111,7 @@ function propConverter(
         getPosition: props.getPosition,
         maintainContainerHeight: props.maintainContainerHeight,
         verticalAlignment: props.verticalAlignment,
+        createTransitionString: props.createTransitionString,
 
         // Do string-to-int conversion for all timing-related props
         duration: this.convertTimingProp('duration'),

--- a/typings/react-flip-move.d.ts
+++ b/typings/react-flip-move.d.ts
@@ -231,5 +231,10 @@ declare namespace FlipMove {
         verticalAlignment?: string;
 
         style?: Styles;
+
+        /**
+         * This function is called to get custom transition css
+         */
+        createTransitionString?(index: string): string;
     }
 }


### PR DESCRIPTION
In my case I want to add background-color transition. 
I think customization the createTransitionString function is a good way, Because we may add other transition.

``` css
{
  transition: transform 500ms ease-in-out 0ms, opacity 500ms ease-in-out 0ms, background-color 500ms ease-in-out 2000ms;
}
```


