### PR TITLE
Add explicit children prop

### DIFF
--- a/typings/react-flip-move.d.ts
+++ b/typings/react-flip-move.d.ts
@@ -26,6 +26,11 @@ declare namespace FlipMove {
     type AnimationProp = AnimationPreset | Animation | boolean;
 
     interface FlipMoveProps {
+        /**
+         * The children to animate. Each child must have a unique key to work correctly.
+         */
+        children?: React.ReactNode;
+
         className?: string;
 
         /**


### PR DESCRIPTION
Hi!

`@types/react` has been updated for react 18 to no longer include an implicit `children` prop on every `Component`. This means `<FlipMove>` is no longer usable with the latest react typings because you must pass `children` to `<FlipMove>` but TypeScript thinks the `<FlipMove>` component doesn't accept any `children`.

This PR adds an explicit `children` prop to the typings including a doc comment.

Thanks!